### PR TITLE
15 feature header 레이아웃

### DIFF
--- a/src/features/header/index.tsx
+++ b/src/features/header/index.tsx
@@ -1,4 +1,1 @@
 export { Header } from '@/features/header/ui/Header';
-export { Brand } from '@/features/header/ui/Brand';
-export { NavMenu } from '@/features/header/ui/NavMenu';
-export { ProfileButton } from '@/features/header/ui/ProfileButton';

--- a/src/features/header/index.tsx
+++ b/src/features/header/index.tsx
@@ -1,4 +1,4 @@
-export { Header } from './ui/Header';
-export { Brand } from './ui/Brand';
-export { NavMenu } from './ui/NavMenu';
-export { ProfileButton } from './ui/ProfileButton';
+export { Header } from '@/features/header/ui/Header';
+export { Brand } from '@/features/header/ui/Brand';
+export { NavMenu } from '@/features/header/ui/NavMenu';
+export { ProfileButton } from '@/features/header/ui/ProfileButton';

--- a/src/features/header/index.tsx
+++ b/src/features/header/index.tsx
@@ -1,0 +1,4 @@
+export { Header } from './ui/Header';
+export { Brand } from './ui/Brand';
+export { NavMenu } from './ui/NavMenu';
+export { ProfileButton } from './ui/ProfileButton';

--- a/src/features/header/model/types.ts
+++ b/src/features/header/model/types.ts
@@ -26,3 +26,5 @@ export type HeaderProps = {
     active: NavKey;
     onSelect: (key: NavKey) => void;
 };
+
+export const BRAND_NAME = 'K-SPOT';

--- a/src/features/header/model/types.ts
+++ b/src/features/header/model/types.ts
@@ -1,0 +1,28 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+/* IconButton 컴포넌트 Props */
+export type IconButtonProps = Omit<ComponentPropsWithoutRef<'button'>, 'children'> & {
+    Icon?: LucideIcon;
+    children?: ReactNode;
+    variant?: 'soft' | 'gradient' | 'outline' | 'ghost';
+    shape?: 'pill' | 'circle';
+    size?: 'sm' | 'md' | 'lg';
+    active?: boolean;
+    iconSize?: number | string;
+};
+
+export type NavKey = 'home' | 'map' | 'saved';
+
+export type MenuItem = {
+    key: NavKey;
+    label: string;
+    to: string;
+    Icon: LucideIcon;
+};
+
+export type HeaderProps = {
+    /* 현재 활성 메뉴 */
+    active: NavKey;
+    onSelect: (key: NavKey) => void;
+};

--- a/src/features/header/model/utils.ts
+++ b/src/features/header/model/utils.ts
@@ -1,0 +1,62 @@
+import { Sparkles, MapPin, Heart } from 'lucide-react';
+import type { MenuItem, NavKey } from '@/features/header/model/types';
+
+/* ----------------------------- 공용 유틸 ----------------------------- */
+export function cn(...xs: Array<string | false | null | undefined>) {
+    return xs.filter(Boolean).join(' ');
+}
+
+/* ----------------------------- 디자인 토큰 ----------------------------- */
+export const sizeClass = {
+    sm: 'h-8 text-sm',
+    md: 'h-10',
+    lg: 'h-11 text-base',
+} as const;
+
+export const pxClass = {
+    sm: 'px-3',
+    md: 'px-4',
+    lg: 'px-5',
+} as const;
+
+export const circleWH = {
+    sm: 'size-8',
+    md: 'size-10',
+    lg: 'size-11',
+} as const;
+
+export const iconSizeByControl = {
+    sm: '1rem',
+    md: '1.125rem',
+    lg: '1.25rem',
+} as const;
+
+/* 유형별 스타일 클래스 */
+export const variantClass = {
+    soft: 'bg-white text-gray-700 hover:text-purple-600 hover:bg-purple-50',
+    gradient:
+        'text-white bg-gradient-to-br from-purple-600 to-pink-600 shadow-lg hover:shadow-xl border border-transparent',
+    outline:
+        'bg-transparent text-gray-700 border border-gray-300 hover:bg-gray-50 hover:text-gray-900',
+    ghost:
+        'bg-transparent text-gray-700 hover:bg-gray-100 hover:text-gray-900',
+} as const;
+
+/* ----------------------------- 네비 데이터/매핑 ----------------------------- */
+export const MENU: MenuItem[] = [
+    { key: 'home', label: '홈', to: '/', Icon: Sparkles },
+    { key: 'map', label: '지도', to: '/map', Icon: MapPin },
+    { key: 'saved', label: '저장됨', to: '/saved', Icon: Heart },
+];
+
+export const keyToPath: Record<NavKey, string> = {
+    home: '/',
+    map: '/map',
+    saved: '/saved',
+};
+
+export function pathToKey(p: string): NavKey {
+    if (p.startsWith('/map')) return 'map';
+    if (p.startsWith('/saved')) return 'saved';
+    return 'home';
+}

--- a/src/features/header/ui/Brand.tsx
+++ b/src/features/header/ui/Brand.tsx
@@ -1,14 +1,15 @@
 import { Sparkles } from 'lucide-react';
+import { BRAND_NAME } from '@/features/header/model/types';
 
 export function Brand() {
   return (
-    <a href="/" className="flex items-center space-x-3 group">
-      <div className="w-10 h-10 bg-gradient-to-br from-purple-600 to-pink-600 rounded-xl flex items-center justify-center transform group-hover:scale-110 transition-transform duration-300">
-        <Sparkles className="w-6 h-6 text-white" />
+    <div className="group flex items-center space-x-3">
+      <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-purple-600 to-pink-600 transition-transform duration-300 group-hover:scale-110">
+        <Sparkles className="h-6 w-6 text-white" aria-hidden />
       </div>
-      <div className="text-2xl font-bold bg-gradient-to-br from-purple-600 to-pink-600 bg-clip-text text-transparent">
-        K-SPOT
+      <div className="bg-gradient-to-br from-purple-600 to-pink-600 bg-clip-text text-2xl font-bold text-transparent">
+        {BRAND_NAME}
       </div>
-    </a>
+    </div>
   );
 }

--- a/src/features/header/ui/Brand.tsx
+++ b/src/features/header/ui/Brand.tsx
@@ -3,10 +3,10 @@ import { Sparkles } from 'lucide-react';
 export function Brand() {
   return (
     <a href="/" className="flex items-center space-x-3 group">
-      <div className="w-10 h-10 bg-gradient-to-r from-purple-600 to-pink-600 rounded-xl flex items-center justify-center transform group-hover:scale-110 transition-transform duration-300">
+      <div className="w-10 h-10 bg-gradient-to-br from-purple-600 to-pink-600 rounded-xl flex items-center justify-center transform group-hover:scale-110 transition-transform duration-300">
         <Sparkles className="w-6 h-6 text-white" />
       </div>
-      <div className="text-2xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
+      <div className="text-2xl font-bold bg-gradient-to-br from-purple-600 to-pink-600 bg-clip-text text-transparent">
         K-SPOT
       </div>
     </a>

--- a/src/features/header/ui/Brand.tsx
+++ b/src/features/header/ui/Brand.tsx
@@ -1,0 +1,14 @@
+import { Sparkles } from 'lucide-react';
+
+export function Brand() {
+  return (
+    <a href="/" className="flex items-center space-x-3 group">
+      <div className="w-10 h-10 bg-gradient-to-r from-purple-600 to-pink-600 rounded-xl flex items-center justify-center transform group-hover:scale-110 transition-transform duration-300">
+        <Sparkles className="w-6 h-6 text-white" />
+      </div>
+      <div className="text-2xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
+        K-SPOT
+      </div>
+    </a>
+  );
+}

--- a/src/features/header/ui/Header.tsx
+++ b/src/features/header/ui/Header.tsx
@@ -1,0 +1,37 @@
+import { Brand } from './Brand';
+import { NavMenu, type NavKey } from './NavMenu';
+import { ProfileButton } from './ProfileButton';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const pathToKey = (p: string): NavKey => {
+  if (p.startsWith('/map')) return 'map';
+  if (p.startsWith('/saved')) return 'saved';
+  return 'home';
+};
+
+const keyToPath: Record<NavKey, string> = {
+  home: '/',
+  map: '/map',
+  saved: '/saved',
+};
+
+export function Header() {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const active = pathToKey(pathname);
+
+  return (
+    <header className="bg-white/90 backdrop-blur-md shadow-lg border-b border-gray-100 sticky top-0 z-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-20">
+          <Brand />
+          <NavMenu
+            active={active}
+            onSelect={(key) => navigate(keyToPath[key])}
+          />
+          <ProfileButton />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/features/header/ui/Header.tsx
+++ b/src/features/header/ui/Header.tsx
@@ -1,6 +1,6 @@
-import { Brand } from './Brand';
-import { NavMenu, type NavKey } from './NavMenu';
-import { ProfileButton } from './ProfileButton';
+import { Brand } from '@/features/header/ui/Brand';
+import { NavMenu, type NavKey } from '@/features/header/ui/NavMenu';
+import { ProfileButton } from '@/features/header/ui/ProfileButton';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 const pathToKey = (p: string): NavKey => {

--- a/src/features/header/ui/Header.tsx
+++ b/src/features/header/ui/Header.tsx
@@ -1,34 +1,15 @@
 import { Brand } from '@/features/header/ui/Brand';
-import { NavMenu, type NavKey } from '@/features/header/ui/NavMenu';
+import { NavMenu } from '@/features/header/ui/NavMenu';
 import { ProfileButton } from '@/features/header/ui/ProfileButton';
-import { useLocation, useNavigate } from 'react-router-dom';
+import type { HeaderProps } from '@/features/header/model/types';
 
-const pathToKey = (p: string): NavKey => {
-  if (p.startsWith('/map')) return 'map';
-  if (p.startsWith('/saved')) return 'saved';
-  return 'home';
-};
-
-const keyToPath: Record<NavKey, string> = {
-  home: '/',
-  map: '/map',
-  saved: '/saved',
-};
-
-export function Header() {
-  const { pathname } = useLocation();
-  const navigate = useNavigate();
-  const active = pathToKey(pathname);
-
+export function Header({ active, onSelect }: HeaderProps) {
   return (
     <header className="bg-white/90 backdrop-blur-md shadow-lg border-b border-gray-100 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-20">
           <Brand />
-          <NavMenu
-            active={active}
-            onSelect={(key) => navigate(keyToPath[key])}
-          />
+          <NavMenu active={active} onSelect={onSelect} />
           <ProfileButton />
         </div>
       </div>

--- a/src/features/header/ui/IconButton.tsx
+++ b/src/features/header/ui/IconButton.tsx
@@ -1,0 +1,105 @@
+import { forwardRef } from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+type IconButtonProps = Omit<React.ComponentPropsWithoutRef<'button'>, 'children'> & {
+  Icon?: LucideIcon;
+  children?: React.ReactNode;
+  variant?: 'soft' | 'gradient' | 'outline' | 'ghost';
+  shape?: 'pill' | 'circle';
+  size?: 'sm' | 'md' | 'lg';
+  active?: boolean;
+  iconSize?: number;
+};
+
+function cn(...xs: Array<string | false | null | undefined>) {
+  return xs.filter(Boolean).join(' ');
+}
+
+const sizeClass = {
+  sm: 'h-8 text-sm',
+  md: 'h-10',
+  lg: 'h-11 text-base',
+} as const;
+
+const pxClass = {
+  sm: 'px-3',
+  md: 'px-4',
+  lg: 'px-5',
+} as const;
+
+const circleWH = {
+  sm: 'size-8',
+  md: 'size-10',
+  lg: 'size-11',
+} as const;
+
+const variantClass = {
+  soft:
+    'bg-white text-gray-600 border border-gray-200 shadow-sm hover:shadow-md hover:text-gray-900 hover:bg-white/50',
+  gradient:
+    'text-white bg-gradient-to-br from-violet-600 via-fuchsia-600 to-rose-400 shadow-lg hover:shadow-xl border border-transparent',
+  outline:
+    'bg-transparent text-gray-600 border border-gray-300 hover:bg-gray-50 hover:text-gray-900',
+  ghost:
+    'bg-transparent text-gray-600 hover:bg-gray-100 hover:text-gray-900',
+} as const;
+
+const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  (
+    {
+      Icon,
+      children,
+      variant = 'soft',
+      shape = 'pill',
+      size = 'md',
+      active = false,
+      iconSize,
+      className,
+      'aria-label': ariaLabel,
+      ...rest
+    },
+    ref
+  ) => {
+    if (!children && !ariaLabel) {
+      console.warn('[IconButton] icon-only 버튼에는 aria-label을 지정하세요.');
+    }
+
+    const isCircle = shape === 'circle';
+    const base =
+      'inline-flex items-center justify-center transition select-none ' +
+      'focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500/60 ' +
+      'disabled:opacity-60 disabled:cursor-not-allowed';
+
+    const visual = active ? variantClass.gradient : variantClass[variant];
+
+    const sizeCls = isCircle
+      ? circleWH[size]
+      : cn(sizeClass[size], pxClass[size], 'rounded-full');
+
+    const iconOnly = !children;
+    const _iconSize =
+      iconSize ?? (size === 'sm' ? 16 : size === 'lg' ? 20 : 18);
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        aria-label={ariaLabel}
+        className={cn(base, sizeCls, 'rounded-full', visual, className)}
+        {...rest}
+      >
+        {Icon ? (
+          <Icon
+            size={_iconSize}
+            className={cn(!iconOnly && 'mr-2', active ? 'text-white' : undefined)}
+          />
+        ) : null}
+        {children}
+      </button>
+    );
+  }
+);
+
+IconButton.displayName = 'IconButton';
+
+export { IconButton };

--- a/src/features/header/ui/IconButton.tsx
+++ b/src/features/header/ui/IconButton.tsx
@@ -1,106 +1,61 @@
 import { forwardRef } from 'react';
-import type { LucideIcon } from 'lucide-react';
+import type { IconButtonProps } from '@/features/header/model/types';
+import {
+  cn,
+  sizeClass,
+  pxClass,
+  circleWH,
+  variantClass,
+  iconSizeByControl,
+} from '@/features/header/model/utils';
 
-type IconButtonProps = Omit<React.ComponentPropsWithoutRef<'button'>, 'children'> & {
-  Icon?: LucideIcon;
-  children?: React.ReactNode;
-  variant?: 'soft' | 'gradient' | 'outline' | 'ghost';
-  shape?: 'pill' | 'circle';
-  size?: 'sm' | 'md' | 'lg';
-  active?: boolean;
-  iconSize?: number;
-};
+const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>((
+  {
+    Icon,
+    children,
+    variant = 'soft',
+    shape = 'pill',
+    size = 'md',
+    active = false,
+    iconSize,
+    className,
+    'aria-label': ariaLabel,
+    ...rest
+  },
+  ref
+) => {
+  const base =
+    'inline-flex items-center justify-center rounded-full transition select-none ' +
+    'focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500/60 ' +
+    'disabled:opacity-60 disabled:cursor-not-allowed';
 
-type ViteImportMeta = ImportMeta & { env?: { DEV?: boolean } };
+  const visual = active ? variantClass.gradient : variantClass[variant];
 
-function cn(...xs: Array<string | false | null | undefined>) {
-  return xs.filter(Boolean).join(' ');
-}
-
-const sizeClass = {
-  sm: 'h-8 text-sm',
-  md: 'h-10',
-  lg: 'h-11 text-base',
-} as const;
-
-const pxClass = {
-  sm: 'px-3',
-  md: 'px-4',
-  lg: 'px-5',
-} as const;
-
-const circleWH = {
-  sm: 'size-8',
-  md: 'size-10',
-  lg: 'size-11',
-} as const;
-
-const variantClass = {
-  soft:
-    'bg-white text-gray-700 hover:shadow-md hover:text-purple-600 hover:bg-purple-50',
-  gradient:
-    'text-white bg-gradient-to-br from-purple-600 to-pink-600 shadow-lg hover:shadow-xl border border-transparent',
-  outline:
-    'bg-transparent text-gray-700 border border-gray-300 hover:bg-gray-50 hover:text-gray-900',
-  ghost:
-    'bg-transparent text-gray-700 hover:bg-gray-100 hover:text-gray-900',
-} as const;
-
-const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
-  (
-    {
-      Icon,
-      children,
-      variant = 'soft',
-      shape = 'pill',
-      size = 'md',
-      active = false,
-      iconSize,
-      className,
-      'aria-label': ariaLabel,
-      ...rest
-    },
-    ref
-  ) => {
-    const isDev = !!((import.meta as ViteImportMeta).env?.DEV);
-    if (!children && !ariaLabel && isDev) {
-      console.warn('IconButton: provide aria-label for icon-only button.');
-    }
-
-    const isCircle = shape === 'circle';
-    const base =
-      'inline-flex items-center justify-center transition select-none ' +
-      'focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500/60 ' +
-      'disabled:opacity-60 disabled:cursor-not-allowed';
-
-    const visual = active ? variantClass.gradient : variantClass[variant];
-
-    const sizeCls = isCircle
+  const sizeCls =
+    shape === 'circle'
       ? circleWH[size]
-      : cn(sizeClass[size], pxClass[size], 'rounded-full');
+      : cn(sizeClass[size], pxClass[size]);
 
-    const iconOnly = !children;
-    const _iconSize = iconSize ?? (size === 'sm' ? 16 : size === 'lg' ? 20 : 18);
+  const resolvedIconSize = iconSize ?? iconSizeByControl[size];
 
-    return (
-      <button
-        ref={ref}
-        type="button"
-        aria-label={ariaLabel}
-        className={cn(base, sizeCls, 'rounded-full', visual, className)}
-        {...rest}
-      >
-        {Icon ? (
-          <Icon
-            size={_iconSize}
-            className={cn(!iconOnly && 'mr-2', active && 'text-white')}
-          />
-        ) : null}
-        {children}
-      </button>
-    );
-  }
-);
+  return (
+    <button
+      ref={ref}
+      type="button"
+      aria-label={ariaLabel}
+      className={cn(base, sizeCls, visual, className)}
+      {...rest}
+    >
+      {Icon ? (
+        <Icon
+          size={resolvedIconSize}
+          className={cn(children ? 'mr-2' : undefined, active ? 'text-white' : undefined)}
+        />
+      ) : null}
+      {children}
+    </button>
+  );
+});
 
 IconButton.displayName = 'IconButton';
 

--- a/src/features/header/ui/IconButton.tsx
+++ b/src/features/header/ui/IconButton.tsx
@@ -11,6 +11,8 @@ type IconButtonProps = Omit<React.ComponentPropsWithoutRef<'button'>, 'children'
   iconSize?: number;
 };
 
+type ViteImportMeta = ImportMeta & { env?: { DEV?: boolean } };
+
 function cn(...xs: Array<string | false | null | undefined>) {
   return xs.filter(Boolean).join(' ');
 }
@@ -35,13 +37,13 @@ const circleWH = {
 
 const variantClass = {
   soft:
-    'bg-white text-gray-600 border border-gray-200 shadow-sm hover:shadow-md hover:text-gray-900 hover:bg-white/50',
+    'bg-white text-gray-700 hover:shadow-md hover:text-purple-600 hover:bg-purple-50',
   gradient:
-    'text-white bg-gradient-to-br from-violet-600 via-fuchsia-600 to-rose-400 shadow-lg hover:shadow-xl border border-transparent',
+    'text-white bg-gradient-to-br from-purple-600 to-pink-600 shadow-lg hover:shadow-xl border border-transparent',
   outline:
-    'bg-transparent text-gray-600 border border-gray-300 hover:bg-gray-50 hover:text-gray-900',
+    'bg-transparent text-gray-700 border border-gray-300 hover:bg-gray-50 hover:text-gray-900',
   ghost:
-    'bg-transparent text-gray-600 hover:bg-gray-100 hover:text-gray-900',
+    'bg-transparent text-gray-700 hover:bg-gray-100 hover:text-gray-900',
 } as const;
 
 const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
@@ -60,8 +62,9 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     },
     ref
   ) => {
-    if (!children && !ariaLabel) {
-      console.warn('[IconButton] icon-only 버튼에는 aria-label을 지정하세요.');
+    const isDev = !!((import.meta as ViteImportMeta).env?.DEV);
+    if (!children && !ariaLabel && isDev) {
+      console.warn('IconButton: provide aria-label for icon-only button.');
     }
 
     const isCircle = shape === 'circle';
@@ -77,8 +80,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
       : cn(sizeClass[size], pxClass[size], 'rounded-full');
 
     const iconOnly = !children;
-    const _iconSize =
-      iconSize ?? (size === 'sm' ? 16 : size === 'lg' ? 20 : 18);
+    const _iconSize = iconSize ?? (size === 'sm' ? 16 : size === 'lg' ? 20 : 18);
 
     return (
       <button
@@ -91,7 +93,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         {Icon ? (
           <Icon
             size={_iconSize}
-            className={cn(!iconOnly && 'mr-2', active ? 'text-white' : undefined)}
+            className={cn(!iconOnly && 'mr-2', active && 'text-white')}
           />
         ) : null}
         {children}

--- a/src/features/header/ui/NavMenu.tsx
+++ b/src/features/header/ui/NavMenu.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { Sparkles, MapPin, Heart } from 'lucide-react';
+
+export type NavKey = 'home' | 'map' | 'saved';
+
+const MENU: { key: NavKey; label: string; href: string; Icon: LucideIcon }[] = [
+  { key: 'home',  label: '홈',   href: '/',      Icon: Sparkles },
+  { key: 'map',   label: '지도', href: '/map',  Icon: MapPin },
+  { key: 'saved', label: '저장됨', href: '/saved', Icon: Heart },
+];
+
+export function NavMenu({
+  active: externalActive,
+  onSelect,
+}: {
+  active?: NavKey;
+  onSelect?: (key: NavKey) => void;
+}) {
+  const [internalActive, setInternalActive] = useState<NavKey>('home');
+  const active = externalActive ?? internalActive;
+
+  const handleClick = (key: NavKey, href: string) => {
+    setInternalActive(key);
+    if (onSelect) {
+      onSelect(key);
+    } else {
+      window.location.href = href;
+    }
+  };
+
+  return (
+    <nav aria-label="주요 메뉴" className="hidden md:flex items-center space-x-8">
+      {MENU.map(({ key, label, href, Icon }) => (
+        <a
+          key={key}
+          href={href}
+          className={`flex items-center space-x-2 px-4 py-2 rounded-full transition-all duration-300 font-medium ${
+            key === active
+              ? 'bg-gradient-to-r from-purple-600 to-pink-600 text-white shadow-lg transform scale-105'
+              : 'text-gray-700 hover:text-purple-600 hover:bg-purple-50'
+          }`}
+          aria-current={key === active ? 'page' : undefined}
+          onClick={(e) => {
+            e.preventDefault();
+            handleClick(key, href);
+          }}
+        >
+          <Icon className="w-4 h-4" />
+          <span>{label}</span>
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/src/features/header/ui/NavMenu.tsx
+++ b/src/features/header/ui/NavMenu.tsx
@@ -1,54 +1,38 @@
-import { useState } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import { Sparkles, MapPin, Heart } from 'lucide-react';
+import { IconButton } from '@/features/header/ui/IconButton';
 
 export type NavKey = 'home' | 'map' | 'saved';
 
 const MENU: { key: NavKey; label: string; href: string; Icon: LucideIcon }[] = [
-  { key: 'home',  label: '홈',   href: '/',      Icon: Sparkles },
+  { key: 'home',  label: '홈',   href: '/',     Icon: Sparkles },
   { key: 'map',   label: '지도', href: '/map',  Icon: MapPin },
   { key: 'saved', label: '저장됨', href: '/saved', Icon: Heart },
 ];
 
 export function NavMenu({
-  active: externalActive,
+  active,
   onSelect,
 }: {
   active?: NavKey;
   onSelect?: (key: NavKey) => void;
 }) {
-  const [internalActive, setInternalActive] = useState<NavKey>('home');
-  const active = externalActive ?? internalActive;
-
-  const handleClick = (key: NavKey, href: string) => {
-    setInternalActive(key);
-    if (onSelect) {
-      onSelect(key);
-    } else {
-      window.location.href = href;
-    }
-  };
-
   return (
-    <nav aria-label="주요 메뉴" className="hidden md:flex items-center space-x-8">
+    <nav aria-label="주요 메뉴" className="hidden md:flex items-center space-x-3">
       {MENU.map(({ key, label, href, Icon }) => (
-        <a
+        <IconButton
           key={key}
-          href={href}
-          className={`flex items-center space-x-2 px-4 py-2 rounded-full transition-all duration-300 font-medium ${
-            key === active
-              ? 'bg-gradient-to-r from-purple-600 to-pink-600 text-white shadow-lg transform scale-105'
-              : 'text-gray-700 hover:text-purple-600 hover:bg-purple-50'
-          }`}
+          Icon={Icon}
+          shape="pill"
+          size="md"
+          variant="soft"
+          active={key === active}
           aria-current={key === active ? 'page' : undefined}
-          onClick={(e) => {
-            e.preventDefault();
-            handleClick(key, href);
-          }}
+          onClick={() => onSelect?.(key)}
+          data-href={href}
         >
-          <Icon className="w-4 h-4" />
-          <span>{label}</span>
-        </a>
+          {label}
+        </IconButton>
       ))}
     </nav>
   );

--- a/src/features/header/ui/NavMenu.tsx
+++ b/src/features/header/ui/NavMenu.tsx
@@ -1,25 +1,16 @@
-import type { LucideIcon } from 'lucide-react';
-import { Sparkles, MapPin, Heart } from 'lucide-react';
 import { IconButton } from '@/features/header/ui/IconButton';
+import { MENU } from '@/features/header/model/utils';
+import type { NavKey } from '@/features/header/model/types';
 
-export type NavKey = 'home' | 'map' | 'saved';
-
-const MENU: { key: NavKey; label: string; href: string; Icon: LucideIcon }[] = [
-  { key: 'home',  label: '홈',   href: '/',     Icon: Sparkles },
-  { key: 'map',   label: '지도', href: '/map',  Icon: MapPin },
-  { key: 'saved', label: '저장됨', href: '/saved', Icon: Heart },
-];
-
-export function NavMenu({
-  active,
-  onSelect,
-}: {
+type NavMenuProps = {
   active?: NavKey;
   onSelect?: (key: NavKey) => void;
-}) {
+};
+
+export function NavMenu({ active, onSelect }: NavMenuProps) {
   return (
     <nav aria-label="주요 메뉴" className="hidden md:flex items-center space-x-3">
-      {MENU.map(({ key, label, href, Icon }) => (
+      {MENU.map(({ key, label, Icon }) => (
         <IconButton
           key={key}
           Icon={Icon}
@@ -29,7 +20,6 @@ export function NavMenu({
           active={key === active}
           aria-current={key === active ? 'page' : undefined}
           onClick={() => onSelect?.(key)}
-          data-href={href}
         >
           {label}
         </IconButton>

--- a/src/features/header/ui/ProfileButton.tsx
+++ b/src/features/header/ui/ProfileButton.tsx
@@ -1,0 +1,9 @@
+import { User } from 'lucide-react';
+
+export function ProfileButton() {
+  return (
+    <button className="p-3 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 transition-all duration-300 shadow-lg">
+      <User className="w-5 h-5 text-white" />
+    </button>
+  );
+}

--- a/src/features/header/ui/ProfileButton.tsx
+++ b/src/features/header/ui/ProfileButton.tsx
@@ -1,9 +1,14 @@
 import { User } from 'lucide-react';
+import { IconButton } from '@/features/header/ui/IconButton';
 
 export function ProfileButton() {
   return (
-    <button className="p-3 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 transition-all duration-300 shadow-lg">
-      <User className="w-5 h-5 text-white" />
-    </button>
+    <IconButton
+      Icon={User}
+      variant="gradient"
+      shape="circle"
+      size="md"
+      aria-label="프로필"
+    />
   );
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

Close #15 

## #️⃣ 작업 내용

Header 영역 레이아웃 작업
- 로고 영역에 해당하는 Brand.tsx 정의
- 화면 이동을 담당하게 될 메뉴 버튼에 해당하는 NavMenu.tsx 정의
- 로그인 후 이용 가능 예정인 페이지로의 이동을 위한 ProfileButton.tsx 기본 구조 정의
- 아이콘과 텍스트가 혼용된 버튼을 위한 공통 컴포넌트인 IconButton.tsx 정의 (아이콘만 존재하는 경우도 가능)
- index.tsx에서는 Header만 export

## ✅ 테스트 체크리스트

- [x] 로컬 환경에서 정상 동작 확인 (build)
- [x] 관련 기능 수동 테스트 완료
- [x] PR을 보내는 브랜치를 다시 확인해주세요.

## #️⃣ 스크린샷 (선택)

<img width="1895" height="101" alt="image" src="https://github.com/user-attachments/assets/9e573e33-7ef4-4535-a690-b463c9148719" />

## #️⃣ 리뷰 요구사항 (선택)

> 우선은 features 내부에서만 작업을 한 상황입니다. 
IconButton을 작업하면서 스타일 토큰을 간략하게 utils.ts에 정의해두었습니다.  
IconButton이라는 컴포넌트 자체가 재사용성이 매우 높기 때문에 shared 폴더로 이동하는 등 
차후 리팩토링 과정을 거치게 될 상황을 고려하여 주석으로 types.ts와 utils.ts에서 IconButton에 해당하는 부분을 구분해두었습니다.
