### PR TITLE
16 feature footer 레이아웃

### DIFF
--- a/src/features/footer/index.ts
+++ b/src/features/footer/index.ts
@@ -1,0 +1,1 @@
+export { Footer } from '@/features/footer/ui/Footer';

--- a/src/features/footer/model/types.ts
+++ b/src/features/footer/model/types.ts
@@ -1,0 +1,45 @@
+import type { LucideIcon } from 'lucide-react';
+import { Mail, Twitter, Youtube, Instagram } from 'lucide-react';
+
+/* ---------------- 타입 정의 ---------------- */
+export type FooterLink = { label: string; href: string };
+export type NavLink = { label: string; to: string };
+export type SocialLink = { label: string; href: string; Icon: LucideIcon };
+
+/* ---------------- 브랜드 상수 ---------------- */
+export const BRAND_NAME = 'K-SPOT';
+export const BRAND_SLOGAN = '한국 문화 콘텐츠를 전 세계와 연결하는 플랫폼입니다.';
+export const BRAND_DESCRIPTION = 'K-Drama, 영화, K-POP 등 다양한 한국 문화를 만나보세요.';
+
+/* ---------------- 카피라이트 ---------------- */
+export const COPYRIGHT_TEXT = `© ${new Date().getFullYear()} KTC. All rights reserved.`;
+
+/* ---------------- 퀵 링크 ---------------- */
+export const FOOTER_QUICK_LINKS: readonly NavLink[] = [
+  { label: '홈', to: '/' },
+  { label: '촬영지 지도', to: '/map' },
+  { label: '저장된 장소', to: '/saved' },
+  { label: '프로필', to: '/profile' },
+];
+
+/* ---------------- 카테고리 ---------------- */
+export const FOOTER_CATEGORIES: readonly NavLink[] = [
+  { label: 'K-드라마', to: '/drama' },
+  { label: 'K-영화', to: '/movie' },
+  { label: 'K-POP', to: '/kpop' },
+];
+
+/* ---------------- 정책 링크 ---------------- */
+export const POLICY_LINKS: readonly FooterLink[] = [
+  { label: '개인정보처리방침', href: '/privacy' },
+  { label: '이용약관', href: '/terms' },
+  { label: '고객센터', href: '/contact' },
+];
+
+/* ---------------- 소셜 링크 ---------------- */
+export const SOCIAL_LINKS: readonly SocialLink[] = [
+  { label: 'Instagram', href: '#', Icon: Instagram },
+  { label: 'YouTube', href: '#', Icon: Youtube },
+  { label: 'Mail', href: '#', Icon: Mail },
+  { label: 'Twitter', href: '#', Icon: Twitter },
+];

--- a/src/features/footer/ui/Brand.tsx
+++ b/src/features/footer/ui/Brand.tsx
@@ -1,0 +1,15 @@
+import { Sparkles } from 'lucide-react';
+import { BRAND_NAME } from '@/features/footer/model/types';
+
+export function Brand() {
+  return (
+    <div className="group flex items-center space-x-3">
+      <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-purple-600 to-pink-600 transition-transform duration-300 group-hover:scale-110">
+        <Sparkles className="h-6 w-6 text-white" aria-hidden />
+      </div>
+      <div className="bg-gradient-to-br from-purple-600 to-pink-600 bg-clip-text text-2xl font-bold text-transparent">
+        {BRAND_NAME}
+      </div>
+    </div>
+  );
+}

--- a/src/features/footer/ui/Footer.tsx
+++ b/src/features/footer/ui/Footer.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { FooterBrand } from '@/features/footer/ui/FooterBrand';
+import { FooterSocialLinks } from '@/features/footer/ui/FooterSocialLinks';
+import { FooterQuickLinks } from '@/features/footer/ui/FooterQuickLinks';
+import { FooterCategories } from '@/features/footer/ui/FooterCategories';
+import { FooterBottom } from '@/features/footer/ui/FooterBottom';
+
+export const Footer: React.FC = () => {
+  return (
+    <footer className="bg-gray-900 text-white" aria-label="사이트 푸터">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12">
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-4">
+          <FooterBrand />
+          <FooterSocialLinks />
+          <FooterQuickLinks />
+          <FooterCategories />
+        </div>
+      </div>
+
+      <FooterBottom />
+    </footer>
+  );
+};

--- a/src/features/footer/ui/FooterBottom.tsx
+++ b/src/features/footer/ui/FooterBottom.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { POLICY_LINKS, COPYRIGHT_TEXT } from '@/features/footer/model/types';
+
+export const FooterBottom: React.FC = () => {
+  return (
+    <div className="border-t border-gray-800">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6 flex flex-col items-center justify-between gap-4 md:flex-row">
+        <p className="text-center text-sm text-gray-400 md:text-left">
+          {COPYRIGHT_TEXT}
+        </p>
+
+        <nav aria-label="정책 링크" className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          {POLICY_LINKS.map(({ label, href }) => (
+            <a
+              key={label}
+              href={href}
+              className="text-sm text-gray-400 transition-colors duration-200 hover:text-white"
+            >
+              {label}
+            </a>
+          ))}
+        </nav>
+      </div>
+    </div>
+  );
+};

--- a/src/features/footer/ui/FooterBrand.tsx
+++ b/src/features/footer/ui/FooterBrand.tsx
@@ -1,20 +1,11 @@
 import React from 'react';
-import { Sparkles } from 'lucide-react';
-import { BRAND_NAME, BRAND_SLOGAN, BRAND_DESCRIPTION } from '@/features/footer/model/types';
+import { BRAND_SLOGAN, BRAND_DESCRIPTION } from '@/features/footer/model/types';
+import { Brand } from '@/features/footer/ui/Brand';
 
 export const FooterBrand: React.FC = () => {
   return (
     <div className="space-y-4">
-      {/* 로고(차후 Brand.tsx 치환 가능) */}
-      <div className="group flex items-center space-x-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-purple-600 to-pink-600 transition-transform duration-300 group-hover:scale-110">
-          <Sparkles className="h-6 w-6 text-white" aria-hidden />
-        </div>
-        <div className="bg-gradient-to-br from-purple-600 to-pink-600 bg-clip-text text-2xl font-bold text-transparent">
-          {BRAND_NAME}
-        </div>
-      </div>
-
+      <Brand />
       <div className="space-y-2">
         <p className="text-sm leading-relaxed text-gray-300">{BRAND_SLOGAN}</p>
         <p className="text-xs text-gray-400">{BRAND_DESCRIPTION}</p>

--- a/src/features/footer/ui/FooterBrand.tsx
+++ b/src/features/footer/ui/FooterBrand.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Sparkles } from 'lucide-react';
+import { BRAND_NAME, BRAND_SLOGAN, BRAND_DESCRIPTION } from '@/features/footer/model/types';
+
+export const FooterBrand: React.FC = () => {
+  return (
+    <div className="space-y-4">
+      {/* 로고(차후 Brand.tsx 치환 가능) */}
+      <div className="group flex items-center space-x-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-purple-600 to-pink-600 transition-transform duration-300 group-hover:scale-110">
+          <Sparkles className="h-6 w-6 text-white" aria-hidden />
+        </div>
+        <div className="bg-gradient-to-br from-purple-600 to-pink-600 bg-clip-text text-2xl font-bold text-transparent">
+          {BRAND_NAME}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-sm leading-relaxed text-gray-300">{BRAND_SLOGAN}</p>
+        <p className="text-xs text-gray-400">{BRAND_DESCRIPTION}</p>
+      </div>
+    </div>
+  );
+};

--- a/src/features/footer/ui/FooterCategories.tsx
+++ b/src/features/footer/ui/FooterCategories.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { FOOTER_CATEGORIES } from '@/features/footer/model/types';
+
+export const FooterCategories: React.FC = () => {
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-white">카테고리</h3>
+      <ul className="space-y-3">
+        {FOOTER_CATEGORIES.map((cat) => (
+          <li key={cat.label}>
+            <a href="#" className="group block">
+              <div className="text-gray-300 transition-colors duration-200 hover:text-white">
+                <div className="text-sm font-medium transition-transform duration-200 group-hover:translate-x-1">
+                  {cat.label}
+                </div>
+              </div>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/src/features/footer/ui/FooterQuickLinks.tsx
+++ b/src/features/footer/ui/FooterQuickLinks.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { FOOTER_QUICK_LINKS } from '@/features/footer/model/types';
+import { Home, MapPin, Heart, User } from 'lucide-react';
+
+const ICONS: Record<string, React.ReactNode> = {
+  '홈': <Home className="h-4 w-4" aria-hidden />,
+  '촬영지 지도': <MapPin className="h-4 w-4" aria-hidden />,
+  '저장된 장소': <Heart className="h-4 w-4" aria-hidden />,
+  '프로필': <User className="h-4 w-4" aria-hidden />,
+};
+
+export const FooterQuickLinks: React.FC = () => {
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-white">빠른 링크</h3>
+      <ul className="space-y-2">
+        {FOOTER_QUICK_LINKS.map((link) => (
+          <li key={link.label}>
+            <a
+              href="#"
+              className="group flex items-center space-x-2 text-gray-300 transition-colors duration-200 hover:text-white"
+            >
+              <span className="transition-transform duration-200 group-hover:scale-110">
+                {ICONS[link.label]}
+              </span>
+              <span className="text-sm">{link.label}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/src/features/footer/ui/FooterSocialLinks.tsx
+++ b/src/features/footer/ui/FooterSocialLinks.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { SOCIAL_LINKS } from '@/features/footer/model/types';
+
+export const FooterSocialLinks: React.FC = () => {
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-white">소셜 미디어</h3>
+      <div className="flex gap-4">
+        {SOCIAL_LINKS.map(({ label, Icon }) => (
+          <a
+            key={label}
+            href="#"
+            aria-label={label}
+            className="rounded-lg p-2 text-gray-400 transition-colors duration-200 hover:bg-gray-800 hover:text-white"
+          >
+            <Icon className="h-5 w-5" aria-hidden />
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## 🔗 연관된 이슈

Close #16 

## #️⃣ 작업 내용

- Footer 레이아웃 구현
  - FooterBrand.tsx 내부에 Brand.tsx로 대체가능한 로고 영역 존재 (차후 대체 예정) + 간략한 설명
  - 소셜 링크로 이어지는 FooterSocialLinks.tsx 작업
  - 내부 페이지 이동으로 이어지는 FooterQuickLinks.tsx 작업
  - 카테고리 선택으로 이어지는 FooterCategorites.tsx 작업
  - Footer의 아랫부분에 해당하는 "저작권, 기타 링크" 영역인 FooterBottom.tsx 작업
- 절대 경로 사용
- tailwind 스타일 적용
- 라우팅 동작 없이 레이아웃 구조만 작성 완료
- 상수 및 type은 types.ts에 정의 완료

## ✅ 테스트 체크리스트

- [x] 로컬 환경에서 정상 동작 확인 (build)
- [x] 관련 기능 수동 테스트 완료
- [x] PR을 보내는 브랜치를 다시 확인해주세요.

## #️⃣ 스크린샷 (선택)

<img width="1883" height="493" alt="image" src="https://github.com/user-attachments/assets/a0f33439-10b4-4245-b3c7-5b6ccdc98ce8" />
