### PR TITLE
feat : 지도 레이아웃 기초 틀 작업

### DIFF
--- a/src/__mocks__/mockPlace.ts
+++ b/src/__mocks__/mockPlace.ts
@@ -1,0 +1,19 @@
+import type { Place } from "@/features/map/model/types";
+
+export const MOCK_PLACES: Place[] = Array.from({ length: 8 }).map((_, idx) => ({
+  id: String(idx + 1),
+  name:
+    idx === 0
+      ? "대한봉진학교"
+      : idx === 1
+      ? "무인도 세트장"
+      : `촬영지 ${idx + 1}`,
+  address:
+    idx === 0
+      ? "경기도 안산시 상록구"
+      : idx === 1
+      ? "인천광역시 중구"
+      : "경기/인천 일대",
+  tags: idx === 0 ? ["메인 촬영지", "학교"] : ["세트", "바다"],
+  rating: 4.8 - idx * 0.1,
+}));

--- a/src/features/map/index.ts
+++ b/src/features/map/index.ts
@@ -1,0 +1,2 @@
+export { MapContainer } from "@/features/map/ui/MapContainer";
+export { Sidebar } from "@/features/map/ui/Sidebar";

--- a/src/features/map/model/types.ts
+++ b/src/features/map/model/types.ts
@@ -1,0 +1,43 @@
+export type MapContainerProps = {
+    className?: string;
+};
+
+export type PlaceCardProps = {
+    thumbnailUrl?: string;
+    name?: string;
+    address?: string;
+    tags?: string[];
+    rating?: number;
+    onClick?: () => void;
+    className?: string;
+    badgeNumber?: number;
+};
+
+export const PLACE_CARD_DEFAULT = {
+    NAME: '장소 이름',
+    ADDRESS: '주소 정보',
+    TAGS: ['촬영지', '메인', '게임'],
+    RATING: 4.8,
+};
+
+export type Place = {
+    id: string;
+    name: string;
+    address: string;
+    tags: string[];
+    rating: number;
+    thumbnailUrl?: string;
+};
+
+export type PlaceListProps = {
+    places?: Place[];
+    className?: string;
+};
+
+export type SidebarProps = {
+    className?: string;
+};
+
+export type SidebarSearchProps = {
+    className?: string;
+};

--- a/src/features/map/ui/Address.tsx
+++ b/src/features/map/ui/Address.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { MapPin } from 'lucide-react';
+
+export const Address: React.FC<{ address: string }> = ({ address }) => {
+  return (
+    <div className="flex items-center text-gray-500 text-sm mb-2">
+      <MapPin className="w-3 h-3 mr-1 flex-shrink-0" />
+      <span className="truncate">{address}</span>
+    </div>
+  );
+};

--- a/src/features/map/ui/MapContainer.tsx
+++ b/src/features/map/ui/MapContainer.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import type { MapContainerProps } from '@/features/map/model/types';
+
+export const MapContainer: React.FC<MapContainerProps> = ({ className }) => {
+  return (
+    <div
+      className={`relative w-full h-full min-h-[600px] bg-gray-100 overflow-hidden ${
+        className ?? ''
+      }`}
+    >
+      <div className="absolute inset-0 flex items-center justify-center text-gray-500 select-none">
+        지도 영역 Placeholder
+      </div>
+    </div>
+  );
+};

--- a/src/features/map/ui/MetaInfo.tsx
+++ b/src/features/map/ui/MetaInfo.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Star, Clock } from 'lucide-react';
+
+export const MetaInfo: React.FC<{ rating: number }> = ({ rating }) => {
+  return (
+    <div className="flex items-center justify-between text-xs text-gray-500">
+      <div className="flex items-center space-x-1">
+        <Star className="w-3 h-3 text-yellow-400" fill="currentColor" />
+        <span>{rating.toFixed(1)}</span>
+      </div>
+      <div className="flex items-center space-x-1">
+        <Clock className="w-3 h-3" />
+        <span>1-2시간</span>
+      </div>
+    </div>
+  );
+};

--- a/src/features/map/ui/PlaceCard.tsx
+++ b/src/features/map/ui/PlaceCard.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Camera } from 'lucide-react';
+import { PLACE_CARD_DEFAULT, type PlaceCardProps } from '@/features/map/model/types';
+import { Thumbnail } from '@/features/map/ui/Thumbnail';
+import { Address } from '@/features/map/ui/Address';
+import { MetaInfo } from '@/features/map/ui/MetaInfo';
+import { TagList } from '@/features/map/ui/TagList';
+
+export const PlaceCard: React.FC<PlaceCardProps> = ({
+  thumbnailUrl,
+  name = PLACE_CARD_DEFAULT.NAME,
+  address = PLACE_CARD_DEFAULT.ADDRESS,
+  tags = PLACE_CARD_DEFAULT.TAGS,
+  rating = PLACE_CARD_DEFAULT.RATING,
+  onClick,
+  className,
+  badgeNumber,
+}) => {
+  return (
+    <div
+      role="button"
+      onClick={onClick}
+      className={[
+        'p-4 border-b border-gray-100 cursor-pointer transition-all hover:bg-gray-50',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div className="flex space-x-4">
+        <Thumbnail thumbnailUrl={thumbnailUrl} name={name} badgeNumber={badgeNumber} />
+        <div className="flex-1 min-w-0">
+          <h3 className="font-bold text-gray-900 mb-1 truncate">{name}</h3>
+          <Address address={address} />
+          <div className="bg-purple-50 rounded-lg p-2 mb-2">
+            <div className="flex items-center space-x-1 mb-1">
+              <Camera className="w-3 h-3 text-purple-600" />
+              <span className="text-xs font-medium text-purple-700">촬영 장면</span>
+            </div>
+            <p className="text-xs text-purple-600 line-clamp-2">
+              {tags.slice(0, 2).join(', ')}
+            </p>
+          </div>
+          <MetaInfo rating={rating} />
+          <TagList tags={tags} />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/map/ui/PlaceList.tsx
+++ b/src/features/map/ui/PlaceList.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { PlaceCard } from "@/features/map/ui/PlaceCard";
+import type { PlaceListProps } from "@/features/map/model/types";
+import { MOCK_PLACES } from "@/__mocks__/mockPlace";
+
+export const PlaceList: React.FC<PlaceListProps> = ({
+  places = MOCK_PLACES,
+  className,
+}) => {
+  return (
+    <div className={"divide-y divide-gray-100 " + (className ?? "")}>
+      {places.map((place, index) => (
+        <PlaceCard
+          key={place.id}
+          name={place.name}
+          address={place.address}
+          tags={place.tags}
+          rating={place.rating}
+          thumbnailUrl={place.thumbnailUrl}
+          badgeNumber={index + 1}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/features/map/ui/Sidebar.tsx
+++ b/src/features/map/ui/Sidebar.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { PlaceList } from "@/features/map/ui/PlaceList";
+import { SidebarSearch } from "@/features/map/ui/SidebarSearch";
+import type { SidebarProps } from "@/features/map/model/types";
+
+export const Sidebar: React.FC<SidebarProps> = ({ className }) => {
+  return (
+    <aside
+      className={
+        "w-full lg:w-96 lg:flex-shrink-0 overflow-hidden h-full " +
+        (className ?? "")
+      }
+    >
+      <div className="w-full lg:w-96 bg-white shadow-xl rounded-r-2xl overflow-hidden h-full flex flex-col border-r border-gray-200">
+        <div className="p-6 bg-gradient-to-r from-purple-600 to-pink-600 text-white">
+          <h2 className="text-xl font-bold mb-2">오징어 게임 촬영지</h2>
+          <p className="text-purple-100 text-sm">4개의 촬영지를 찾았습니다</p>
+        </div>
+
+        <SidebarSearch />
+        <div className="flex-1 overflow-y-auto">
+          <PlaceList />
+        </div>
+        <div className="p-4 bg-gray-50 border-t border-gray-200">
+          <div className="text-center">
+            <p className="text-xs text-gray-500 mb-2">🎬 오징어 게임 촬영지 탐방</p>
+            <div className="flex items-center justify-center space-x-4 text-xs text-gray-400">
+              <span>📍 4개 장소</span>
+              <span>⭐ 평균 4.6점</span>
+              <span>⏱️ 2-3시간</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+};

--- a/src/features/map/ui/SidebarSearch.tsx
+++ b/src/features/map/ui/SidebarSearch.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Search } from "lucide-react";
+import type { SidebarSearchProps } from "@/features/map/model/types";
+
+export const SidebarSearch: React.FC<SidebarSearchProps> = ({ className }) => {
+  return (
+    <div className={("p-4 border-b border-gray-200 " + (className ?? "")).trim()}>
+      <div className="relative">
+        <input
+          type="text"
+          placeholder="촬영지 검색... (예: 오징어게임, 대한봉진학교)"
+          className="w-full pl-10 pr-4 py-3 border border-gray-200 rounded-xl focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none"
+        />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+      </div>
+      <p className="mt-2 text-xs text-gray-500">
+        💡 팁: "오징어게임"으로 검색하면 모든 촬영지가 표시됩니다
+      </p>
+    </div>
+  );
+};

--- a/src/features/map/ui/TagList.tsx
+++ b/src/features/map/ui/TagList.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export const TagList: React.FC<{ tags: string[] }> = ({ tags }) => {
+  return (
+    <div className="mt-2 flex flex-wrap gap-1">
+      {tags.slice(0, 2).map((tag) => (
+        <span
+          key={tag}
+          className="px-2 py-1 bg-gray-100 text-gray-600 text-xs rounded-md"
+        >
+          {tag}
+        </span>
+      ))}
+      {tags.length > 2 && (
+        <span className="text-xs text-gray-400">+{tags.length - 2}</span>
+      )}
+    </div>
+  );
+};

--- a/src/features/map/ui/Thumbnail.tsx
+++ b/src/features/map/ui/Thumbnail.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Camera } from 'lucide-react';
+import type { PlaceCardProps } from '@/features/map/model/types';
+
+type Props = Pick<PlaceCardProps, 'thumbnailUrl' | 'name' | 'badgeNumber'>;
+
+export const Thumbnail: React.FC<Props> = ({ thumbnailUrl, name, badgeNumber }) => {
+  return (
+    <div className="relative flex-shrink-0">
+      <div className="w-16 h-16 rounded-xl overflow-hidden bg-gray-100 border border-gray-200">
+        {thumbnailUrl ? (
+          <img
+            alt={name}
+            src={thumbnailUrl}
+            className="w-full h-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-full grid place-items-center text-gray-400">
+            <Camera size={20} className="opacity-70" />
+          </div>
+        )}
+      </div>
+
+      {typeof badgeNumber === 'number' && (
+        <div className="absolute -top-2 -left-2 w-6 h-6 bg-gradient-to-r from-purple-600 to-pink-600 rounded-full flex items-center justify-center text-white text-xs font-bold">
+          {badgeNumber}
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## 🔗 연관된 이슈

Close #17 

## #️⃣ 작업 내용

- 지도 화면 레이아웃 구현
  - 사이드바 (장소 목록 띄우는 화면)
  - 지도 영역 (단순 영역 표시만 진행)
  - 장소 각각의 정보를 담는 PlaceCard 컴포넌트 생성
  - PlaceCard 내부 요소들을 개별 컴포넌트화 시켜서 가독성 향상
  - Sidebar, MapContainer만 index.ts에서 export
  - 장소 데이터 mock로 2개 정도만 넣어봄

## ✅ 테스트 체크리스트

- [x] 로컬 환경에서 정상 동작 확인 (build)
- [x] 관련 기능 수동 테스트 완료
- [x] PR을 보내는 브랜치를 다시 확인해주세요.

## #️⃣ 스크린샷 (선택)

<img width="1915" height="920" alt="image" src="https://github.com/user-attachments/assets/14d2bd1e-0606-40e3-b844-9c3b9bcdb63f" />
