### PR TITLE
80 feature global layout 동작 및 not found 화면 구현

### DIFF
--- a/src/features/Footer/model/hooks.ts
+++ b/src/features/Footer/model/hooks.ts
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+
+export interface CategoryState {
+  category: string;
+  title: string;
+}
+
+export function useCategoryModal() {
+  const [selectedCategory, setSelectedCategory] = useState<CategoryState | null>(null);
+
+  // Footer 카테고리를 CategorySection과 동일한 key로 매핑
+  const getCategoryKey = (label: string) => {
+    switch (label) {
+      case 'K-Drama':
+        return 'drama';
+      case 'K-Movie':
+        return 'movie';
+      case 'K-POP':
+        return 'pop';
+      default:
+        return label.toLowerCase();
+    }
+  };
+
+  const handleCategoryClick = (category: string, title: string) => {
+    setSelectedCategory({ category, title });
+  };
+
+  const handleCloseModal = () => {
+    setSelectedCategory(null);
+  };
+
+  return {
+    selectedCategory,
+    getCategoryKey,
+    handleCategoryClick,
+    handleCloseModal,
+  };
+}

--- a/src/features/Footer/model/messages.ts
+++ b/src/features/Footer/model/messages.ts
@@ -21,8 +21,8 @@ export const LABELS = {
     PROFILE: '프로필',
   },
   CATEGORY: {
-    DRAMA: 'K-드라마',
-    MOVIE: 'K-영화',
+    DRAMA: 'K-Drama',
+    MOVIE: 'K-Movie',
     KPOP: 'K-POP',
   },
   POLICY: {

--- a/src/features/Footer/ui/FooterContentCategories/FooterContentCategories.tsx
+++ b/src/features/Footer/ui/FooterContentCategories/FooterContentCategories.tsx
@@ -1,24 +1,40 @@
 import { FOOTER_CATEGORIES } from '../../model/constants';
 import { FOOTER_TITLES } from '../../model/messages';
-import { Link } from '@tanstack/react-router';
+import { useCategoryModal } from '../../model/hooks';
+import { CategoryModal } from '@/features/Modal/ui/CategoryModal';
 
 export function FooterContentCategories() {
+  const { selectedCategory, getCategoryKey, handleCategoryClick, handleCloseModal } =
+    useCategoryModal();
+
   return (
-    <div className="flex flex-col gap-(--spacing-4)">
-      <h3 className="text-heading-4 text-(--color-text-inverse)">{FOOTER_TITLES.CATEGORIES}</h3>
-      <ul className="flex flex-col gap-(--spacing-3)">
-        {FOOTER_CATEGORIES.map((cat) => (
-          <li key={cat.label}>
-            <Link
-              to={cat.to}
-              className="block text-(--color-text-secondary) transition-colors duration-200 hover:text-(--color-text-inverse)
-                        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-primary)/60 focus-visible:ring-offset-2"
-            >
-              <span className="text-body-small font-medium">{cat.label}</span>
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <>
+      <div className="flex flex-col gap-(--spacing-4)">
+        <h3 className="text-heading-4 text-(--color-text-inverse)">{FOOTER_TITLES.CATEGORIES}</h3>
+        <ul className="flex flex-col gap-(--spacing-3)">
+          {FOOTER_CATEGORIES.map((cat) => (
+            <li key={cat.label}>
+              <button
+                onClick={() => handleCategoryClick(getCategoryKey(cat.label), cat.label)}
+                className="block text-(--color-text-secondary) transition-colors duration-200 hover:text-(--color-text-inverse)
+                          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-primary)/60 focus-visible:ring-offset-2
+                          text-left w-full"
+              >
+                <span className="text-body-small font-medium">{cat.label}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {selectedCategory && (
+        <CategoryModal
+          isOpen={!!selectedCategory}
+          onClose={handleCloseModal}
+          category={selectedCategory.category}
+          categoryTitle={selectedCategory.title}
+        />
+      )}
+    </>
   );
 }

--- a/src/features/Footer/ui/FooterSocialLinks/FooterSocialLinks.tsx
+++ b/src/features/Footer/ui/FooterSocialLinks/FooterSocialLinks.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@tanstack/react-router';
 import { SOCIAL_LINKS } from '../../model/constants';
 import { FOOTER_TITLES } from '../../model/messages';
 
@@ -7,14 +8,14 @@ export function FooterSocialLinks() {
       <h3 className="text-heading-4 text-(--color-text-inverse)">{FOOTER_TITLES.SOCIAL}</h3>
       <div className="flex gap-(--spacing-4)">
         {SOCIAL_LINKS.map(({ label, Icon }) => (
-          <a
+          <Link
             key={label}
-            href="#"
+            to="/not-found"
             aria-label={label}
             className="rounded-(--radius-md) p-(--spacing-2) text-(--color-text-tertiary) transition-colors duration-200 hover:bg-(--color-muted) hover:text-(--color-text-inverse)"
           >
             <Icon className="h-(--spacing-5) w-(--spacing-5)" aria-hidden />
-          </a>
+          </Link>
         ))}
       </div>
     </div>

--- a/src/features/Header/ui/Brand/Brand.tsx
+++ b/src/features/Header/ui/Brand/Brand.tsx
@@ -1,10 +1,16 @@
 import { Sparkles } from 'lucide-react';
+import { Link } from '@tanstack/react-router';
 import { BRAND_NAME } from '../../model/messages';
 import { circleWH } from '@/shared/model/styles';
 
 export function Brand() {
   return (
-    <div className="group flex items-center gap-(--spacing-4)">
+    <Link
+      to="/"
+      onClick={() => window.scrollTo(0, 0)}
+      className="group flex items-center gap-(--spacing-4) transition-opacity duration-200 hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-primary)/60 focus-visible:ring-offset-2 rounded-lg"
+      aria-label="홈페이지로 이동"
+    >
       <div
         className={`flex ${circleWH.md} items-center justify-center rounded-(--radius-xl) bg-gradient-to-br from-(--color-primary) to-(--color-accent) shadow-(--shadow-brand-md) transition-transform duration-300 group-hover:scale-110`}
       >
@@ -16,6 +22,6 @@ export function Brand() {
       <div className="bg-gradient-to-br from-(--color-primary) to-(--color-accent) bg-clip-text text-heading-3 text-transparent">
         {BRAND_NAME}
       </div>
-    </div>
+    </Link>
   );
 }

--- a/src/features/Header/ui/ProfileButton/ProfileButton.tsx
+++ b/src/features/Header/ui/ProfileButton/ProfileButton.tsx
@@ -1,6 +1,11 @@
 import { User } from 'lucide-react';
+import { Link } from '@tanstack/react-router';
 import { IconButton } from '@/shared/ui';
 
 export function ProfileButton() {
-  return <IconButton Icon={User} variant="gradient" shape="circle" size="md" aria-label="프로필" />;
+  return (
+    <Link to="/not-found" aria-label="프로필 페이지로 이동">
+      <IconButton Icon={User} variant="gradient" shape="circle" size="md" aria-label="프로필" />
+    </Link>
+  );
 }

--- a/src/pages/__root.tsx
+++ b/src/pages/__root.tsx
@@ -1,5 +1,6 @@
 import { createRootRoute, Outlet } from '@tanstack/react-router';
 import { GlobalLayout } from '@/app/layout/GlobalLayout';
+import { NotFoundPage } from './not-found';
 
 export const Route = createRootRoute({
   component: () => (
@@ -10,4 +11,5 @@ export const Route = createRootRoute({
       )}
     </GlobalLayout>
   ),
+  notFoundComponent: NotFoundPage,
 });

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,0 +1,262 @@
+import { createFileRoute, Link, useRouter } from '@tanstack/react-router';
+import { ArrowLeft, MessageCircle, Mail, Phone, Clock, HelpCircle, Send } from 'lucide-react';
+
+export const Route = createFileRoute('/contact')({
+  component: ContactPage,
+});
+
+function ContactPage() {
+  const router = useRouter();
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    alert('문의가 완료되었습니다.');
+    router.navigate({ to: '/' });
+  };
+
+  return (
+    <main className="min-h-screen bg-(--color-background-primary)">
+      <div className="max-w-4xl mx-auto px-(--spacing-4) py-(--spacing-8)">
+        {/* 헤더 */}
+        <header className="mb-(--spacing-8) animate-slide-down">
+          <Link
+            to="/"
+            className="inline-flex items-center gap-(--spacing-2) text-(--color-brand-secondary) hover:text-(--color-brand-tertiary) font-medium mb-(--spacing-4) transition-colors duration-200"
+          >
+            <ArrowLeft className="w-4 h-4" aria-hidden />
+            홈으로 돌아가기
+          </Link>
+
+          <div className="flex items-center gap-(--spacing-3) mb-(--spacing-4)">
+            <div className="w-12 h-12 bg-(--color-brand-primary) rounded-lg flex items-center justify-center shadow-(--shadow-brand-sm)">
+              <MessageCircle className="w-6 h-6 text-(--color-brand-secondary)" aria-hidden />
+            </div>
+            <div>
+              <h1 className="text-heading-1 text-(--color-text-primary)">고객센터</h1>
+              <p className="text-(--color-text-tertiary) text-body-small">
+                언제든지 문의해주세요. 빠르게 답변드리겠습니다.
+              </p>
+            </div>
+          </div>
+        </header>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-(--spacing-8) animate-fade-in">
+          {/* 연락처 정보 */}
+          <aside className="lg:col-span-1">
+            <section className="bg-(--color-background-secondary) rounded-lg p-(--spacing-6) mb-(--spacing-6) shadow-(--shadow-card)">
+              <h2 className="text-heading-4 text-(--color-text-primary) mb-(--spacing-4)">
+                연락처 정보
+              </h2>
+              <div className="space-y-(--spacing-4)">
+                <div className="flex items-center gap-(--spacing-3)">
+                  <div className="w-10 h-10 bg-(--color-brand-primary) rounded-lg flex items-center justify-center shadow-(--shadow-brand-sm)">
+                    <Phone className="w-5 h-5 text-(--color-brand-secondary)" aria-hidden />
+                  </div>
+                  <div>
+                    <p className="font-medium text-(--color-text-primary) text-body">전화 문의</p>
+                    <p className="text-(--color-text-secondary) text-body-small">02-1234-5678</p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-(--spacing-3)">
+                  <div className="w-10 h-10 bg-(--color-brand-primary) rounded-lg flex items-center justify-center shadow-(--shadow-brand-sm)">
+                    <Mail className="w-5 h-5 text-(--color-brand-secondary)" aria-hidden />
+                  </div>
+                  <div>
+                    <p className="font-medium text-(--color-text-primary) text-body">이메일 문의</p>
+                    <p className="text-(--color-text-secondary) text-body-small">
+                      support@k-spot.com
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-(--spacing-3)">
+                  <div className="w-10 h-10 bg-(--color-brand-primary) rounded-lg flex items-center justify-center shadow-(--shadow-brand-sm)">
+                    <Clock className="w-5 h-5 text-(--color-brand-secondary)" aria-hidden />
+                  </div>
+                  <div>
+                    <p className="font-medium text-(--color-text-primary) text-body">운영 시간</p>
+                    <p className="text-(--color-text-secondary) text-body-small">
+                      평일 09:00 - 18:00
+                    </p>
+                    <p className="text-(--color-text-tertiary) text-caption">
+                      (주말 및 공휴일 휴무)
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            {/* 자주 묻는 질문 */}
+            <section className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+              <h2 className="text-heading-4 text-(--color-text-primary) mb-(--spacing-4) flex items-center gap-(--spacing-2)">
+                <HelpCircle className="w-5 h-5 text-(--color-brand-secondary)" aria-hidden />
+                자주 묻는 질문
+              </h2>
+              <ul className="space-y-(--spacing-3)">
+                <li className="border-l-4 border-(--color-brand-primary) pl-(--spacing-4)">
+                  <p className="font-medium text-(--color-text-primary) text-body-small">
+                    회원가입은 어떻게 하나요?
+                  </p>
+                  <p className="text-(--color-text-secondary) text-body-small mt-(--spacing-1)">
+                    홈페이지 우상단의 프로필 아이콘을 클릭하여 회원가입을 진행할 수 있습니다.
+                  </p>
+                </li>
+                <li className="border-l-4 border-(--color-brand-primary) pl-(--spacing-4)">
+                  <p className="font-medium text-(--color-text-primary) text-body-small">
+                    촬영지 정보는 정확한가요?
+                  </p>
+                  <p className="text-(--color-text-secondary) text-body-small mt-(--spacing-1)">
+                    모든 촬영지 정보는 신뢰할 수 있는 API를 통해 정보를 제공합니다.
+                  </p>
+                </li>
+                <li className="border-l-4 border-(--color-brand-primary) pl-(--spacing-4)">
+                  <p className="font-medium text-(--color-text-primary) text-body-small">
+                    회원가입을 하지 않으면 불이익이 있나요?
+                  </p>
+                  <p className="text-(--color-text-secondary) text-body-small mt-(--spacing-1)">
+                    회원가입을 하신 후에 나만의 동선 저장하기 기능을 사용하실 수 있습니다.
+                  </p>
+                </li>
+              </ul>
+            </section>
+          </aside>
+
+          {/* 문의 양식 */}
+          <section className="lg:col-span-2">
+            <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+              <h2 className="text-heading-4 text-(--color-text-primary) mb-(--spacing-6)">
+                문의하기
+              </h2>
+
+              <form className="space-y-(--spacing-6)" onSubmit={handleSubmit}>
+                {/* 이름, 이메일 */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-(--spacing-4)">
+                  <div>
+                    <label
+                      htmlFor="name"
+                      className="block text-body-small font-medium text-(--color-text-primary) mb-(--spacing-2)"
+                    >
+                      이름 *
+                    </label>
+                    <input
+                      type="text"
+                      id="name"
+                      name="name"
+                      required
+                      className="w-full px-(--spacing-3) py-(--spacing-2) border border-(--color-border-primary) rounded-lg focus:outline-none focus:ring-2 focus:ring-(--color-brand-secondary) focus:border-transparent text-body"
+                      placeholder="이름을 입력해주세요"
+                    />
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="email"
+                      className="block text-body-small font-medium text-(--color-text-primary) mb-(--spacing-2)"
+                    >
+                      이메일 *
+                    </label>
+                    <input
+                      type="email"
+                      id="email"
+                      name="email"
+                      required
+                      className="w-full px-(--spacing-3) py-(--spacing-2) border border-(--color-border-primary) rounded-lg focus:outline-none focus:ring-2 focus:ring-(--color-brand-secondary) focus:border-transparent text-body"
+                      placeholder="이메일을 입력해주세요"
+                    />
+                  </div>
+                </div>
+
+                {/* 문의 유형 */}
+                <div>
+                  <label
+                    htmlFor="subject"
+                    className="block text-body-small font-medium text-(--color-text-primary) mb-(--spacing-2)"
+                  >
+                    문의 유형 *
+                  </label>
+                  <select
+                    id="subject"
+                    name="subject"
+                    required
+                    className="w-full px-(--spacing-3) py-(--spacing-2) border border-(--color-border-primary) rounded-lg focus:outline-none focus:ring-2 focus:ring-(--color-brand-secondary) focus:border-transparent text-body"
+                  >
+                    <option value="">문의 유형을 선택해주세요</option>
+                    <option value="account">계정 관련</option>
+                    <option value="service">서비스 이용</option>
+                    <option value="technical">기술적 문제</option>
+                    <option value="suggestion">개선 제안</option>
+                    <option value="other">기타</option>
+                  </select>
+                </div>
+
+                {/* 메시지 */}
+                <div>
+                  <label
+                    htmlFor="message"
+                    className="block text-body-small font-medium text-(--color-text-primary) mb-(--spacing-2)"
+                  >
+                    문의 내용 *
+                  </label>
+                  <textarea
+                    id="message"
+                    name="message"
+                    rows={6}
+                    required
+                    className="w-full px-(--spacing-3) py-(--spacing-2) border border-(--color-border-primary) rounded-lg focus:outline-none focus:ring-2 focus:ring-(--color-brand-secondary) focus:border-transparent text-body"
+                    placeholder="문의하실 내용을 자세히 적어주세요"
+                  ></textarea>
+                </div>
+
+                {/* 개인정보 동의 */}
+                <div className="flex items-start gap-(--spacing-3)">
+                  <input
+                    type="checkbox"
+                    id="privacy"
+                    name="privacy"
+                    required
+                    className="mt-(--spacing-1) w-4 h-4 text-(--color-brand-secondary) border-(--color-border-primary) rounded focus:ring-(--color-brand-secondary)"
+                  />
+                  <label
+                    htmlFor="privacy"
+                    className="text-body-small text-(--color-text-secondary)"
+                  >
+                    개인정보 수집 및 이용에 동의합니다.
+                    <Link
+                      to="/privacy"
+                      className="text-(--color-brand-secondary) hover:text-(--color-brand-tertiary) underline"
+                    >
+                      개인정보처리방침
+                    </Link>
+                    을 확인했습니다.
+                  </label>
+                </div>
+
+                <button
+                  type="submit"
+                  className="w-full bg-(--color-brand-secondary) hover:bg-(--color-brand-tertiary) text-(--color-text-inverse) font-medium py-(--spacing-3) px-(--spacing-6) rounded-lg transition-colors duration-200 flex items-center justify-center gap-(--spacing-2) text-button-large shadow-(--shadow-button-hover)"
+                >
+                  <Send className="w-5 h-5" aria-hidden />
+                  문의하기
+                </button>
+              </form>
+            </div>
+
+            {/* 추가 안내 */}
+            <section className="mt-(--spacing-12) bg-(--color-brand-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-brand-md)">
+              <h3 className="text-heading-4 text-(--color-text-primary) mb-(--spacing-4) flex items-center gap-(--spacing-2)">
+                문의 시 참고사항
+              </h3>
+              <ul className="text-(--color-text-secondary) mb-(--spacing-4) text-body list-disc pl-(--spacing-4)">
+                <li>• 문의하신 내용에 대한 답변은 이메일로 발송됩니다.</li>
+                <li>• 일반적인 문의는 1-2일 내에 답변드립니다.</li>
+                <li>• 긴급한 문의는 전화로 연락해주시기 바랍니다.</li>
+                <li>• 개인정보는 문의 처리 목적으로만 사용됩니다.</li>
+              </ul>
+            </section>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/not-found.tsx
+++ b/src/pages/not-found.tsx
@@ -1,0 +1,76 @@
+import { createFileRoute, Link, useRouter } from '@tanstack/react-router';
+import { Home, ArrowLeft, Search } from 'lucide-react';
+
+export const Route = createFileRoute('/not-found')({
+  component: NotFoundPage,
+});
+
+export function NotFoundPage() {
+  const router = useRouter();
+  const btnBase =
+    'inline-flex items-center justify-center gap-(--spacing-2) w-full py-(--spacing-3) px-(--spacing-6) rounded-lg font-medium transition-colors duration-200 text-button-large';
+
+  const goBack = () => {
+    if (window.history.length > 1) {
+      router.history.back();
+    } else {
+      router.navigate({ to: '/' });
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-(--color-background-primary) flex items-center justify-center px-(--spacing-4)">
+      <main className="max-w-md w-full text-center">
+        <header className="mb-(--spacing-8)">
+          <div className="mx-auto w-32 h-32 rounded-full flex items-center justify-center mb-(--spacing-4) bg-gradient-to-br from-(--color-brand-primary) to-(--color-brand-secondary) shadow-(--shadow-brand-lg)">
+            <Search className="w-16 h-16 text-(--color-brand-secondary)" aria-hidden="true" />
+          </div>
+
+          <div
+            className="text-6xl font-bold text-(--color-text-primary) mb-(--spacing-2)"
+            aria-hidden="true"
+          >
+            404
+          </div>
+          <h1 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4)">
+            페이지를 찾을 수 없습니다
+          </h1>
+          <p className="text-(--color-text-secondary) text-body-large leading-relaxed">
+            요청하신 페이지가 존재하지 않거나
+            <br />
+            이동되었을 수 있습니다.
+          </p>
+        </header>
+
+        <div className="space-y-(--spacing-4)">
+          <Link
+            to="/"
+            className={`${btnBase} bg-(--color-brand-secondary) hover:bg-(--color-brand-tertiary) text-(--color-text-inverse) shadow-(--shadow-button-hover)`}
+          >
+            <Home className="w-5 h-5" aria-hidden="true" />
+            홈으로 돌아가기
+          </Link>
+
+          <button
+            onClick={goBack}
+            className={`${btnBase} bg-(--color-background-secondary) hover:bg-(--color-background-tertiary) text-(--color-text-primary) shadow-(--shadow-button)`}
+          >
+            <ArrowLeft className="w-5 h-5" aria-hidden="true" />
+            이전 페이지로
+          </button>
+        </div>
+
+        <section className="mt-(--spacing-12) pt-(--spacing-8) border-t border-(--color-border-primary)">
+          <h2 className="text-heading-5 text-(--color-text-primary) mb-(--spacing-4)">
+            도움이 필요하신가요?
+          </h2>
+          <ul className="space-y-(--spacing-2) text-body-small text-(--color-text-tertiary)">
+            <li>• URL을 다시 확인해보세요</li>
+            <li>• 홈페이지에서 원하는 콘텐츠를 찾아보세요</li>
+            <li>• 문제가 지속되면 고객센터에 문의해주세요</li>
+          </ul>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -1,0 +1,182 @@
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { ArrowLeft, Shield, FileText, Eye, Lock, Database } from 'lucide-react';
+
+export const Route = createFileRoute('/privacy')({
+  component: PrivacyPage,
+});
+
+function PrivacyPage() {
+  return (
+    <main className="min-h-screen bg-(--color-background-primary)">
+      <div className="max-w-4xl mx-auto px-(--spacing-4) py-(--spacing-8)">
+        {/* 헤더 */}
+        <header className="mb-(--spacing-8) animate-slide-down">
+          <Link
+            to="/"
+            className="inline-flex items-center gap-(--spacing-2) text-(--color-brand-secondary) hover:text-(--color-brand-tertiary) font-medium mb-(--spacing-4) transition-colors duration-200"
+          >
+            <ArrowLeft className="w-4 h-4" aria-hidden />
+            홈으로 돌아가기
+          </Link>
+
+          <div className="flex items-center gap-(--spacing-3) mb-(--spacing-4)">
+            <div className="w-12 h-12 bg-(--color-brand-primary) rounded-lg flex items-center justify-center shadow-(--shadow-brand-sm)">
+              <Shield className="w-6 h-6 text-(--color-brand-secondary)" aria-hidden />
+            </div>
+            <div>
+              <h1 className="text-heading-1 text-(--color-text-primary)">개인정보처리방침</h1>
+              <p className="text-(--color-text-tertiary) text-body-small">
+                마지막 업데이트: 2025년 10월 1일
+              </p>
+            </div>
+          </div>
+        </header>
+
+        {/* 본문 내용 */}
+        <article className="prose prose-lg max-w-none animate-fade-in">
+          <section className="bg-(--color-background-secondary) rounded-lg p-(--spacing-6) mb-(--spacing-8) shadow-(--shadow-card)">
+            <h2 className="text-heading-4 text-(--color-text-primary) mb-(--spacing-4) flex items-center gap-(--spacing-2)">
+              <FileText className="w-5 h-5 text-(--color-brand-secondary)" aria-hidden />
+              개인정보 수집 및 이용에 대한 안내
+            </h2>
+            <p className="text-(--color-text-primary) leading-relaxed text-body">
+              K-SPOT은 이용자의 개인정보를 보호하기 위해 최선을 다하고 있습니다. 본
+              개인정보처리방침은 K-SPOT 서비스 이용 시 수집되는 개인정보의 처리에 관한 사항을
+              안내합니다.
+            </p>
+          </section>
+
+          <div className="space-y-(--spacing-8)">
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4) flex items-center gap-(--spacing-2)">
+                <Eye className="w-6 h-6 text-(--color-brand-secondary)" aria-hidden />
+                1. 수집하는 개인정보의 항목
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <h3 className="text-heading-5 text-(--color-text-primary) mb-(--spacing-3)">
+                  필수 수집 항목
+                </h3>
+                <ul className="space-y-(--spacing-2) text-(--color-text-secondary) text-body">
+                  <li>• 이메일 주소</li>
+                  <li>• 닉네임</li>
+                  <li>• 서비스 이용 기록</li>
+                </ul>
+
+                <h3 className="text-heading-5 text-(--color-text-primary) mb-(--spacing-3) mt-(--spacing-6)">
+                  선택 수집 항목
+                </h3>
+                <ul className="space-y-(--spacing-2) text-(--color-text-secondary) text-body">
+                  <li>• 프로필 사진</li>
+                  <li>• 관심 카테고리</li>
+                  <li>• 위치 정보 (선택적)</li>
+                </ul>
+              </div>
+            </section>
+
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4) flex items-center gap-(--spacing-2)">
+                <Database className="w-6 h-6 text-(--color-brand-secondary)" aria-hidden />
+                2. 개인정보의 수집 및 이용 목적
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <ul className="space-y-(--spacing-3) text-(--color-text-secondary) text-body">
+                  <li>• 서비스 제공 및 계약 이행</li>
+                  <li>• 회원 식별 및 본인 확인</li>
+                  <li>• 고객 상담 및 문의 응답</li>
+                  <li>• 서비스 개선 및 신규 서비스 개발</li>
+                  <li>• 마케팅 및 광고 활용 (동의 시)</li>
+                </ul>
+              </div>
+            </section>
+
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4) flex items-center gap-(--spacing-2)">
+                <Lock className="w-6 h-6 text-(--color-brand-secondary)" aria-hidden />
+                3. 개인정보의 보유 및 이용 기간
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <p className="text-(--color-text-secondary) mb-(--spacing-4) text-body">
+                  회원 탈퇴 시까지 보유하며, 탈퇴 후에는 즉시 파기합니다. 단, 관련 법령에 의해
+                  보존이 필요한 경우 해당 기간 동안 보관합니다.
+                </p>
+                <div className="text-body-small text-(--color-text-tertiary)">
+                  <p>• 계약 또는 청약철회 등에 관한 기록: 5년</p>
+                  <p>• 대금결제 및 재화 등의 공급에 관한 기록: 5년</p>
+                  <p>• 소비자의 불만 또는 분쟁처리에 관한 기록: 3년</p>
+                </div>
+              </div>
+            </section>
+
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4)">
+                4. 개인정보의 제3자 제공
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <p className="text-(--color-text-secondary) text-body">
+                  K-SPOT은 이용자의 개인정보를 원칙적으로 외부에 제공하지 않습니다. 다만, 이용자가
+                  사전에 동의한 경우나 법령의 규정에 의한 경우는 예외로 합니다.
+                </p>
+              </div>
+            </section>
+
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4)">
+                5. 개인정보 보호를 위한 기술적/관리적 대책
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <ul className="space-y-(--spacing-3) text-(--color-text-secondary) text-body">
+                  <li>• 개인정보 암호화</li>
+                  <li>• 해킹 등에 대비한 기술적 대책</li>
+                  <li>• 개인정보에 대한 접근 제한</li>
+                  <li>• 접속기록의 보관 및 위변조 방지</li>
+                  <li>• 개인정보의 안전한 저장을 위한 기술의 적용</li>
+                </ul>
+              </div>
+            </section>
+
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4)">
+                6. 개인정보 보호책임자
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <div className="space-y-(--spacing-2) text-(--color-text-secondary) text-body">
+                  <p>
+                    <strong>성명:</strong> 김개인정보
+                  </p>
+                  <p>
+                    <strong>소속:</strong> K-SPOT 개인정보보호팀
+                  </p>
+                  <p>
+                    <strong>연락처:</strong> privacy@k-spot.com
+                  </p>
+                  <p>
+                    <strong>전화:</strong> 02-1234-5678
+                  </p>
+                </div>
+              </div>
+            </section>
+          </div>
+
+          {/* 연락처 섹션 */}
+          <footer className="mt-(--spacing-12) bg-(--color-brand-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-brand-md)">
+            <h2 className="text-heading-4 text-(--color-text-primary) mb-(--spacing-4)">
+              문의사항이 있으신가요?
+            </h2>
+            <p className="text-(--color-text-secondary) mb-(--spacing-4) text-body">
+              개인정보처리방침에 대한 문의사항이나 개인정보 관련 요청사항이 있으시면 언제든지
+              연락해주세요.
+            </p>
+            <div className="flex flex-wrap gap-(--spacing-4)">
+              <Link
+                to="/contact"
+                className="inline-flex items-center gap-(--spacing-2) bg-(--color-brand-secondary) hover:bg-(--color-brand-tertiary) text-(--color-text-inverse) font-medium py-(--spacing-2) px-(--spacing-4) rounded-lg transition-colors duration-200 text-button shadow-(--shadow-button-hover)"
+              >
+                고객센터 문의
+              </Link>
+            </div>
+          </footer>
+        </article>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -1,0 +1,293 @@
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { ArrowLeft, FileText, Users, AlertCircle } from 'lucide-react';
+
+export const Route = createFileRoute('/terms')({
+  component: TermsPage,
+});
+
+function TermsPage() {
+  return (
+    <main className="min-h-screen bg-(--color-background-primary)">
+      <div className="max-w-4xl mx-auto px-(--spacing-4) py-(--spacing-8)">
+        {/* 헤더 */}
+        <header className="mb-(--spacing-8) animate-slide-down">
+          <Link
+            to="/"
+            className="inline-flex items-center gap-(--spacing-2) text-(--color-brand-secondary) hover:text-(--color-brand-tertiary) font-medium mb-(--spacing-4) transition-colors duration-200"
+          >
+            <ArrowLeft className="w-4 h-4" aria-hidden />
+            홈으로 돌아가기
+          </Link>
+
+          <div className="flex items-center gap-(--spacing-3) mb-(--spacing-4)">
+            <div className="w-12 h-12 bg-(--color-brand-primary) rounded-lg flex items-center justify-center shadow-(--shadow-brand-sm)">
+              <FileText className="w-6 h-6 text-(--color-brand-secondary)" aria-hidden />
+            </div>
+            <div>
+              <h1 className="text-heading-1 text-(--color-text-primary)">이용약관</h1>
+              <p className="text-(--color-text-tertiary) text-body-small">
+                마지막 업데이트: 2025년 10월 1일
+              </p>
+            </div>
+          </div>
+        </header>
+
+        {/* 본문 내용 */}
+        <article className="prose prose-lg max-w-none animate-fade-in">
+          <section className="bg-(--color-background-secondary) rounded-lg p-(--spacing-6) mb-(--spacing-8) shadow-(--shadow-card)">
+            <h2 className="text-heading-4 text-(--color-text-primary) mb-(--spacing-4) flex items-center gap-(--spacing-2)">
+              <Users className="w-5 h-5 text-(--color-brand-secondary)" aria-hidden />
+              서비스 이용약관
+            </h2>
+            <p className="text-(--color-text-primary) leading-relaxed text-body">
+              본 약관은 K-SPOT 서비스(이하 "서비스")를 이용하는 이용자와 서비스 제공자 간의 권리,
+              의무 및 책임사항을 규정함을 목적으로 합니다.
+            </p>
+          </section>
+
+          <div className="space-y-(--spacing-8)">
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4)">
+                제1조 (목적)
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <p className="text-(--color-text-secondary) leading-relaxed text-body">
+                  본 약관은 K-SPOT이 제공하는 한국 문화 콘텐츠 관련 서비스의 이용과 관련하여 회사와
+                  이용자 간의 권리, 의무 및 책임사항을 규정함을 목적으로 합니다.
+                </p>
+              </div>
+            </section>
+
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4)">
+                제2조 (정의)
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <div className="space-y-(--spacing-4) text-(--color-text-secondary) text-body">
+                  <div>
+                    <p className="font-medium">1. "서비스"란</p>
+                    <p className="ml-(--spacing-4)">
+                      K-SPOT이 제공하는 한국 문화 콘텐츠 관련 정보 제공, 촬영지 정보, 지도 서비스
+                      등을 의미합니다.
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-medium">2. "이용자"란</p>
+                    <p className="ml-(--spacing-4)">
+                      서비스에 접속하여 본 약관에 따라 서비스를 이용하는 회원 및 비회원을
+                      의미합니다.
+                    </p>
+                  </div>
+                  <div>
+                    <p className="font-medium">3. "회원"이란</p>
+                    <p className="ml-(--spacing-4)">
+                      서비스에 개인정보를 제공하여 회원등록을 한 자로서, 서비스의 정보를 지속적으로
+                      제공받으며 서비스를 계속적으로 이용할 수 있는 자를 의미합니다.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4)">
+                제3조 (약관의 효력 및 변경)
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <div className="space-y-(--spacing-4) text-(--color-text-secondary) text-body">
+                  <p>
+                    1. 본 약관은 서비스 화면에 게시하거나 기타의 방법으로 이용자에게 공지함으로써
+                    효력이 발생합니다.
+                  </p>
+                  <p>
+                    2. 회사는 합리적인 사유가 발생할 경우에는 본 약관을 변경할 수 있으며, 약관이
+                    변경되는 경우 변경된 약관의 내용과 시행일을 정하여, 시행일로부터 최소 7일 이전에
+                    공지합니다.
+                  </p>
+                  <p>
+                    3. 이용자가 변경된 약관에 동의하지 않는 경우, 이용자는 본인의 회원등록을
+                    취소(회원탈퇴)할 수 있으며, 계속 사용하시는 경우에는 약관 변경에 동의한 것으로
+                    간주됩니다.
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4)">
+                제4조 (서비스의 제공 및 변경)
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <div className="space-y-(--spacing-4) text-(--color-text-secondary) text-body">
+                  <p>1. 회사는 다음과 같은 업무를 수행합니다:</p>
+                  <ul className="ml-(--spacing-6) space-y-(--spacing-2)">
+                    <li>• 한국 문화 콘텐츠 정보 제공 서비스</li>
+                    <li>• 촬영지 정보 및 지도 서비스</li>
+                    <li>• 관련 부가서비스 및 기타 회사가 정하는 업무</li>
+                  </ul>
+                  <p>
+                    2. 회사는 서비스의 기술적 사양의 변경 등의 경우에는 장차 체결되는 계약에 의해
+                    제공할 서비스의 내용을 변경할 수 있습니다.
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4)">
+                제5조 (서비스의 중단)
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <div className="space-y-(--spacing-4) text-(--color-text-secondary) text-body">
+                  <p>
+                    1. 회사는 컴퓨터 등 정보통신설비의 보수점검, 교체 및 고장, 통신의 두절 등의
+                    사유가 발생한 경우에는 서비스의 제공을 일시적으로 중단할 수 있습니다.
+                  </p>
+                  <p>
+                    2. 회사는 제1항의 사유로 서비스의 제공이 일시적으로 중단됨으로 인하여 이용자
+                    또는 제3자가 입은 손해에 대하여 배상합니다. 단, 회사가 고의 또는 과실이 없음을
+                    입증하는 경우에는 그러하지 아니합니다.
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4)">
+                제6조 (회원가입)
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <div className="space-y-(--spacing-4) text-(--color-text-secondary) text-body">
+                  <p>
+                    1. 이용자는 회사가 정한 가입 양식에 따라 회원정보를 기입한 후 이 약관에
+                    동의한다는 의사표시를 함으로서 회원가입을 신청합니다.
+                  </p>
+                  <p>
+                    2. 회사는 제1항과 같이 회원으로 가입할 것을 신청한 이용자 중 다음 각 호에
+                    해당하지 않는 한 회원으로 등록합니다:
+                  </p>
+                  <ul className="ml-(--spacing-6) space-y-(--spacing-2)">
+                    <li>• 가입신청자가 이 약관에 의하여 이전에 회원자격을 상실한 적이 있는 경우</li>
+                    <li>• 등록 내용에 허위, 기재누락, 오기가 있는 경우</li>
+                    <li>
+                      • 기타 회원으로 등록하는 것이 회사의 기술상 현저히 지장이 있다고 판단되는 경우
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </section>
+
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4)">
+                제7조 (회원 탈퇴 및 자격 상실 등)
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <div className="space-y-(--spacing-4) text-(--color-text-secondary) text-body">
+                  <p>
+                    1. 회원은 회사에 언제든지 탈퇴를 요청할 수 있으며 회사는 즉시 회원탈퇴를
+                    처리합니다.
+                  </p>
+                  <p>
+                    2. 회원이 다음 각 호의 사유에 해당하는 경우, 회사는 회원자격을 제한 및 정지시킬
+                    수 있습니다:
+                  </p>
+                  <ul className="ml-(--spacing-6) space-y-(--spacing-2)">
+                    <li>• 가입 신청 시에 허위 내용을 등록한 경우</li>
+                    <li>
+                      • 다른 사람의 서비스 이용을 방해하거나 그 정보를 도용하는 등 전자상거래 질서를
+                      위협하는 경우
+                    </li>
+                    <li>
+                      • 서비스를 이용하여 법령 또는 이 약관이 금지하거나 공서양속에 반하는 행위를
+                      하는 경우
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </section>
+
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4)">
+                제8조 (회원에 대한 통지)
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <div className="space-y-(--spacing-4) text-(--color-text-secondary) text-body">
+                  <p>
+                    1. 회사가 회원에 대한 통지를 하는 경우, 회원이 회사와 미리 약정하여 지정한
+                    전자우편 주소로 할 수 있습니다.
+                  </p>
+                  <p>
+                    2. 회사는 불특정다수 회원에 대한 통지의 경우 1주일이상 서비스 게시판에
+                    게시함으로서 개별 통지에 갈음할 수 있습니다.
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4)">
+                제9조 (개인정보보호)
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <div className="space-y-(--spacing-4) text-(--color-text-secondary) text-body">
+                  <p>
+                    1. 회사는 이용자의 개인정보 수집시 서비스제공을 위하여 필요한 범위에서 최소한의
+                    개인정보를 수집합니다.
+                  </p>
+                  <p>2. 회사는 회원가입시 구매계약이행에 필요한 정보를 미리 수집하지 않습니다.</p>
+                  <p>
+                    3. 회사는 이용자의 개인정보를 수집·이용하는 때에는 당해 이용자에게 그 목적을
+                    고지하고 동의를 받습니다.
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className="animate-slide-up">
+              <h2 className="text-heading-2 text-(--color-text-primary) mb-(--spacing-4)">
+                제10조 (면책조항)
+              </h2>
+              <div className="bg-(--color-background-primary) border border-(--color-border-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-card)">
+                <div className="space-y-(--spacing-4) text-(--color-text-secondary) text-body">
+                  <p>
+                    1. 회사는 천재지변 또는 이에 준하는 불가항력으로 인하여 서비스를 제공할 수 없는
+                    경우에는 서비스 제공에 관한 책임이 면제됩니다.
+                  </p>
+                  <p>
+                    2. 회사는 이용자의 귀책사유로 인한 서비스 이용의 장애에 대하여는 책임을 지지
+                    않습니다.
+                  </p>
+                  <p>
+                    3. 회사는 이용자가 서비스를 이용하여 기대하는 수익을 상실한 것에 대하여 책임을
+                    지지 않으며 그 밖에 서비스를 통하여 얻은 자료로 인한 손해에 관하여는 책임을 지지
+                    않습니다.
+                  </p>
+                </div>
+              </div>
+            </section>
+          </div>
+
+          {/* 연락처 섹션 */}
+          <footer className="mt-(--spacing-12) bg-(--color-brand-primary) rounded-lg p-(--spacing-6) shadow-(--shadow-brand-md)">
+            <h2 className="text-heading-4 text-(--color-text-primary) mb-(--spacing-4) flex items-center gap-(--spacing-2)">
+              <AlertCircle className="w-5 h-5 text-(--color-brand-secondary)" aria-hidden />
+              문의사항이 있으신가요?
+            </h2>
+            <p className="text-(--color-text-secondary) mb-(--spacing-4) text-body">
+              이용약관에 대한 문의사항이나 서비스 이용과 관련된 문제가 있으시면 언제든지
+              연락해주세요.
+            </p>
+            <div className="flex flex-wrap gap-(--spacing-4)">
+              <Link
+                to="/contact"
+                className="inline-flex items-center gap-(--spacing-2) bg-(--color-brand-secondary) hover:bg-(--color-brand-tertiary) text-(--color-text-inverse) font-medium py-(--spacing-2) px-(--spacing-4) rounded-lg transition-colors duration-200 text-button shadow-(--shadow-button-hover)"
+              >
+                고객센터 문의
+              </Link>
+            </div>
+          </footer>
+        </article>
+      </div>
+    </main>
+  );
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,15 +9,39 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './pages/__root'
+import { Route as TermsRouteImport } from './pages/terms'
+import { Route as PrivacyRouteImport } from './pages/privacy'
+import { Route as NotFoundRouteImport } from './pages/not-found'
 import { Route as MapRouteImport } from './pages/map'
+import { Route as ContactRouteImport } from './pages/contact'
 import { Route as IndexRouteImport } from './pages/index'
 import { Route as LocationIdRouteImport } from './pages/location.$id'
 import { Route as ContentIdRouteImport } from './pages/content.$id'
 import { Route as ContentContentIdMapRouteImport } from './pages/content.$contentId.map'
 
+const TermsRoute = TermsRouteImport.update({
+  id: '/terms',
+  path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const NotFoundRoute = NotFoundRouteImport.update({
+  id: '/not-found',
+  path: '/not-found',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MapRoute = MapRouteImport.update({
   id: '/map',
   path: '/map',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ContactRoute = ContactRouteImport.update({
+  id: '/contact',
+  path: '/contact',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -43,14 +67,22 @@ const ContentContentIdMapRoute = ContentContentIdMapRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/contact': typeof ContactRoute
   '/map': typeof MapRoute
+  '/not-found': typeof NotFoundRoute
+  '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
   '/content/$id': typeof ContentIdRoute
   '/location/$id': typeof LocationIdRoute
   '/content/$contentId/map': typeof ContentContentIdMapRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/contact': typeof ContactRoute
   '/map': typeof MapRoute
+  '/not-found': typeof NotFoundRoute
+  '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
   '/content/$id': typeof ContentIdRoute
   '/location/$id': typeof LocationIdRoute
   '/content/$contentId/map': typeof ContentContentIdMapRoute
@@ -58,7 +90,11 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/contact': typeof ContactRoute
   '/map': typeof MapRoute
+  '/not-found': typeof NotFoundRoute
+  '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
   '/content/$id': typeof ContentIdRoute
   '/location/$id': typeof LocationIdRoute
   '/content/$contentId/map': typeof ContentContentIdMapRoute
@@ -67,21 +103,33 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/contact'
     | '/map'
+    | '/not-found'
+    | '/privacy'
+    | '/terms'
     | '/content/$id'
     | '/location/$id'
     | '/content/$contentId/map'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/contact'
     | '/map'
+    | '/not-found'
+    | '/privacy'
+    | '/terms'
     | '/content/$id'
     | '/location/$id'
     | '/content/$contentId/map'
   id:
     | '__root__'
     | '/'
+    | '/contact'
     | '/map'
+    | '/not-found'
+    | '/privacy'
+    | '/terms'
     | '/content/$id'
     | '/location/$id'
     | '/content/$contentId/map'
@@ -89,7 +137,11 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ContactRoute: typeof ContactRoute
   MapRoute: typeof MapRoute
+  NotFoundRoute: typeof NotFoundRoute
+  PrivacyRoute: typeof PrivacyRoute
+  TermsRoute: typeof TermsRoute
   ContentIdRoute: typeof ContentIdRoute
   LocationIdRoute: typeof LocationIdRoute
   ContentContentIdMapRoute: typeof ContentContentIdMapRoute
@@ -97,11 +149,39 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/terms': {
+      id: '/terms'
+      path: '/terms'
+      fullPath: '/terms'
+      preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/not-found': {
+      id: '/not-found'
+      path: '/not-found'
+      fullPath: '/not-found'
+      preLoaderRoute: typeof NotFoundRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/map': {
       id: '/map'
       path: '/map'
       fullPath: '/map'
       preLoaderRoute: typeof MapRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/contact': {
+      id: '/contact'
+      path: '/contact'
+      fullPath: '/contact'
+      preLoaderRoute: typeof ContactRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -137,7 +217,11 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ContactRoute: ContactRoute,
   MapRoute: MapRoute,
+  NotFoundRoute: NotFoundRoute,
+  PrivacyRoute: PrivacyRoute,
+  TermsRoute: TermsRoute,
   ContentIdRoute: ContentIdRoute,
   LocationIdRoute: LocationIdRoute,
   ContentContentIdMapRoute: ContentContentIdMapRoute,


### PR DESCRIPTION
## 🔗 연관된 이슈

Close #80

## #️⃣ 작업 내용

Header의 "로고, 프로필 버튼"에 동작 구현
Footer의 모든 버튼에 동작 구현

- 로고: 클릭시 홈페이지로 이동, 만약 홈페이지에서 로고 클릭시 최상단으로 스크롤 이동
- 프로필 버튼/Footer의 "저장된 장소, 프로필": 현재는 not-found로 연결 (화면으로 이동하는 동작 구현에 집중하여 진행)
> 차후 마이페이지 코드 참고하여 마이페이지로 연결할 예정
- 소셜미디어 버튼: not-found로 연결
- K-Drama, K-Movie, K-POP: 각각에 해당하는 모달이 뜨도록 연결
- 개인정보, 이용약관, 고객센터: 가상의 UI 생성 후 연결

## ✅ 테스트 체크리스트

- [x] 로컬 환경에서 정상 동작 확인 (build)
- [x] 관련 기능 수동 테스트 완료
- [x] PR을 보내는 브랜치를 다시 확인해주세요.

## #️⃣ 스크린샷 (선택)

<img width="1428" height="336" alt="image" src="https://github.com/user-attachments/assets/41b7637a-8eba-43b2-8b44-e4ca0614d999" />
<img width="1381" height="916" alt="image" src="https://github.com/user-attachments/assets/e8c9e4f2-e4a1-4349-937f-89856ca411c1" />
<img width="1321" height="876" alt="image" src="https://github.com/user-attachments/assets/92f42971-b2b4-41b1-9d3a-1f9b0c4705c7" />
<img width="1286" height="877" alt="image" src="https://github.com/user-attachments/assets/7d2c09ae-beb8-404a-a0c0-f027df8e2940" />
