### PR TITLE
83 feature 컨텐츠 상세 페이지 기능 개선 및 스타일 수정

### DIFF
--- a/src/features/ContentOverviewHero/model/types.ts
+++ b/src/features/ContentOverviewHero/model/types.ts
@@ -19,6 +19,5 @@ export interface ContentOverviewInfoProps {
 }
 
 export interface ContentOverviewActionButtonsProps {
-  onLocationViewClick?: () => void;
   onMapViewClick?: () => void;
 }

--- a/src/features/ContentOverviewHero/ui/ContentOverviewActionButton/ContentOverviewActionButtons.tsx
+++ b/src/features/ContentOverviewHero/ui/ContentOverviewActionButton/ContentOverviewActionButtons.tsx
@@ -1,31 +1,20 @@
-import { MapPin, Map } from 'lucide-react';
+import { Map } from 'lucide-react';
 import { IconButton } from '@/shared/ui';
 import type { ContentOverviewActionButtonsProps } from '../../model/types';
 import { messages } from '../../model/messages';
 
 export function ContentOverviewActionButtons({
-  onLocationViewClick,
   onMapViewClick,
 }: ContentOverviewActionButtonsProps) {
   return (
-    <div className="absolute bottom-8 left-0 right-0 z-[--z-elevated] px-[--spacing-6]">
+    <div className="px-[--spacing-6] py-[--spacing-8]">
       <div className="max-w-2xl mx-auto">
-        <div className="flex flex-col sm:flex-row gap-[--spacing-4] justify-center">
-          <IconButton
-            Icon={MapPin}
-            shape="pill"
-            size="lg"
-            className="bg-[--color-background-primary] text-[--color-text-primary] text-button-large px-[--spacing-8] py-[--spacing-4] hover:bg-[--color-background-secondary] shadow-[--shadow-button] hover:shadow-[--shadow-button-hover] transition-all duration-200"
-            onClick={onLocationViewClick}
-          >
-            {messages.locationView}
-          </IconButton>
-
+        <div className="flex flex-col sm:flex-row gap-6 justify-center">
           <IconButton
             Icon={Map}
             shape="pill"
             size="lg"
-            className="bg-white/15 text-[--color-text-inverse] text-button-large px-[--spacing-8] py-[--spacing-4] border border-white/30 hover:bg-white/25 shadow-[--shadow-button] hover:shadow-[--shadow-button-hover] transition-all duration-200"
+            className="bg-[--color-brand-tertiary] text-[--color-text-inverse] text-button-large px-[--spacing-8] py-[--spacing-4] border border-white/30 hover:bg-white/25 shadow-[--shadow-button] hover:shadow-[--shadow-button-hover] transition-all duration-200"
             onClick={onMapViewClick}
           >
             {messages.mapView}

--- a/src/features/ContentOverviewHero/ui/ContentOverviewHero/ContentOverviewHero.tsx
+++ b/src/features/ContentOverviewHero/ui/ContentOverviewHero/ContentOverviewHero.tsx
@@ -6,6 +6,7 @@ import type { ContentOverviewHeroProps } from '../../model/types';
 import { useContentDetail } from '@/entities/content/api/queryfn';
 import { getContentLocations } from '@/entities/content/api/contentApi';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 
 export function ContentOverviewHero({
   contentId,
@@ -17,6 +18,12 @@ export function ContentOverviewHero({
     queryKey: ['content-locations', contentId],
     queryFn: () => getContentLocations(contentId),
   });
+
+  const navigate = useNavigate();
+
+  const handleMapViewClick = () => {
+    navigate({ to: `/content/${contentId}/map` });
+  };
   return (
     <section className="bg-gradient-to-t from-(--color-gray-800) to-(--color-gray-900)">
       <div className="mx-auto max-w-7xl px-[--spacing-4] sm:px-[--spacing-6] lg:px-[--spacing-8]">
@@ -41,7 +48,7 @@ export function ContentOverviewHero({
 
         {/* 하단 액션 버튼들 */}
         <div>
-          <ContentOverviewActionButtons />
+          <ContentOverviewActionButtons onMapViewClick={handleMapViewClick} />
         </div>
       </div>
     </section>

--- a/src/features/ContentOverviewHero/ui/ContentOverviewHero/ContentOverviewHero.tsx
+++ b/src/features/ContentOverviewHero/ui/ContentOverviewHero/ContentOverviewHero.tsx
@@ -1,5 +1,5 @@
 import { contentHero } from '@/__mocks__/contentHero';
-import { ContentOverviewIconGroup } from '../ContentOverviewIconGroup/ContentOverviewIconGroup';
+
 import { ContentOverviewInfo } from '../ContentOverviewInfo/ContentOverviewInfo';
 import { ContentOverviewActionButtons } from '../ContentOverviewActionButton/ContentOverviewActionButtons';
 import type { ContentOverviewHeroProps } from '../../model/types';
@@ -10,7 +10,6 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 export function ContentOverviewHero({
   contentId,
   description = contentHero.description,
-  isLiked = false,
 }: ContentOverviewHeroProps) {
   const { data } = useContentDetail(contentId);
 
@@ -19,27 +18,32 @@ export function ContentOverviewHero({
     queryFn: () => getContentLocations(contentId),
   });
   return (
-    <div className="relative h-screen-safe w-full overflow-hidden">
-      {/* 배경 이미지 */}
-      <div className="absolute inset-0">
-        <img src={data.posterImageUrl} alt={data.title} className="w-full h-full object-cover" />
-        {/* 그라데이션 오버레이 */}
-        <div className="absolute inset-0 bg-gradient-to-b from-[var(--color-gray-0)] to-[var(--color-gray-800)]" />
+    <section className="bg-gradient-to-t from-(--color-gray-800) to-(--color-gray-900)">
+      <div className="mx-auto max-w-7xl px-[--spacing-4] sm:px-[--spacing-6] lg:px-[--spacing-8]">
+        {/* 이미지 */}
+        <div className="relative h-[32rem] md:h-[48rem] rounded-2xl overflow-hidden">
+          <img
+            src={data.posterImageUrl}
+            alt={data.title}
+            className="absolute inset-0 w-full h-full object-cover object-center rounded-2xl"
+          />
+        </div>
+
+        {/* 콘텐츠 정보 */}
+        <div className="text-gray-900 ">
+          <ContentOverviewInfo
+            title={data.title}
+            category={data.category}
+            description={description}
+            countOfLocations={contentLocations.length}
+          />
+        </div>
+
+        {/* 하단 액션 버튼들 */}
+        <div>
+          <ContentOverviewActionButtons />
+        </div>
       </div>
-
-      {/* 상단 아이콘 그룹 */}
-      <ContentOverviewIconGroup isLiked={isLiked} />
-
-      {/* 콘텐츠 정보 */}
-      <ContentOverviewInfo
-        title={data.title}
-        category={data.category}
-        description={description}
-        countOfLocations={contentLocations.length}
-      />
-
-      {/* 하단 액션 버튼들 */}
-      <ContentOverviewActionButtons />
-    </div>
+    </section>
   );
 }

--- a/src/features/ContentOverviewHero/ui/ContentOverviewInfo/ContentOverviewInfo.tsx
+++ b/src/features/ContentOverviewHero/ui/ContentOverviewInfo/ContentOverviewInfo.tsx
@@ -8,14 +8,17 @@ export function ContentOverviewInfo({
   countOfLocations,
 }: ContentOverviewInfoProps) {
   return (
-    <div className="absolute bottom-32 left-0 right-0 z-[--z-elevated] px-[--spacing-6]">
+    <div className="px-[--spacing-16] py-[--spacing-8]">
       <div className="max-w-4xl mx-auto text-center">
-        <div className="mb-[--spacing-6] flex items-center justify-center gap-[--spacing-4]">
+        <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold text-white/90 mb-12 leading-tight ">
+          {title}
+        </h1>
+        <div className="mb-8 flex items-center justify-center gap-6">
           <span
             className="
               px-[--spacing-6] py-[--spacing-3] 
               bg-gradient-to-r from-[--color-brand-secondary] to-[--color-brand-tertiary] 
-              text-white text-sm font-semibold rounded-full
+              text-white text-2xl font-semibold rounded-full
               shadow-[--shadow-brand-sm]
           "
           >
@@ -31,18 +34,14 @@ export function ContentOverviewInfo({
               "
             >
               <div className="w-2 h-2 bg-white rounded-full"></div>
-              <span className="text-white/90 text-sm font-medium">
+              <span className="text-white/90 text-2xl font-medium">
                 {messages.locationCount.replace('{count}', countOfLocations.toString())}
               </span>
             </div>
           )}
         </div>
 
-        <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold text-white mb-[--spacing-6] leading-tight">
-          {title}
-        </h1>
-
-        <p className="text-white/80 text-lg md:text-xl leading-relaxed max-w-2xl mx-auto">
+        <p className="text-white/90 text-xl md:text-2xl leading-relaxed max-w-2xl mx-auto mb-8">
           {description}
         </p>
       </div>

--- a/src/features/LocationImageCarousel/ui/LocationImageActionButton/LocationImageActionButton.tsx
+++ b/src/features/LocationImageCarousel/ui/LocationImageActionButton/LocationImageActionButton.tsx
@@ -1,14 +1,20 @@
 import { messages } from '../../model/messages';
 
-export function LocationImageActionButton() {
+interface LocationImageActionButtonProps {
+  onClick: () => void;
+  showAll: boolean;
+}
+
+export function LocationImageActionButton({ onClick, showAll }: LocationImageActionButtonProps) {
   return (
     <div className="text-center mt-(--spacing-12)">
       <button
+        onClick={onClick}
         className="
           bg-(--color-brand-tertiary) text-heading-5 text-(--color-text-inverse) px-(--spacing-8) py-(--spacing-3) rounded-(--radius-xl) 
           transition-all hover:scale-105 active:scale-95"
       >
-        {messages.allLocationView}
+        {showAll ? '접기' : messages.allLocationView}
       </button>
     </div>
   );

--- a/src/features/LocationImageCarousel/ui/LocationImageCarousel/LocationImageCarousel.tsx
+++ b/src/features/LocationImageCarousel/ui/LocationImageCarousel/LocationImageCarousel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useLocationImageCarousel } from '../../hooks/useLocationImageCarousel';
 import { useLocationData } from '../../hooks/useLocationData';
 import { LocationImageHeader } from '../LocationImageHeader/LocationImageHeader';
@@ -8,10 +9,17 @@ import type { LocationImageCarouselProps } from '../../model/types';
 
 export function LocationImageCarousel({ contentId }: LocationImageCarouselProps) {
   const { locations } = useLocationData(contentId);
+  const [showAllThumbnails, setShowAllThumbnails] = useState(false);
 
   const { scenes, currentIndex, nextSlide, prevSlide, goToSlide } = useLocationImageCarousel({
     locations,
   });
+
+  const handleToggleThumbnails = () => {
+    setShowAllThumbnails(!showAllThumbnails);
+  };
+
+  const displayScenes = showAllThumbnails ? scenes : scenes.slice(0, 4);
 
   if (scenes.length === 0) {
     return (
@@ -39,12 +47,14 @@ export function LocationImageCarousel({ contentId }: LocationImageCarouselProps)
         />
 
         <LocationImageThumbnails
-          scenes={scenes}
+          scenes={displayScenes}
           currentIndex={currentIndex}
           onGoToSlide={goToSlide}
         />
 
-        <LocationImageActionButton />
+        {scenes.length > 4 && (
+          <LocationImageActionButton onClick={handleToggleThumbnails} showAll={showAllThumbnails} />
+        )}
       </div>
     </section>
   );

--- a/src/features/LocationImageCarousel/ui/LocationImageThumbnails/LocationImageThumbnails.tsx
+++ b/src/features/LocationImageCarousel/ui/LocationImageThumbnails/LocationImageThumbnails.tsx
@@ -1,16 +1,31 @@
 import type { LocationImageThumbnailsProps } from '../../model/types';
+import { useNavigate } from '@tanstack/react-router';
 
 export function LocationImageThumbnails({
   scenes,
   currentIndex,
   onGoToSlide,
 }: LocationImageThumbnailsProps) {
+  const navigate = useNavigate();
+
+  const handleThumbnailClick = (sceneId: string, event: React.MouseEvent) => {
+    event.preventDefault();
+    navigate({ to: `/location/${sceneId}` });
+  };
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-(--spacing-4)">
       {scenes.map((scene, index) => (
         <div
           key={scene.id}
-          onClick={() => onGoToSlide(index)}
+          onClick={(event) => {
+            if (event.ctrlKey || event.metaKey) {
+              // Ctrl/Cmd + 클릭시 슬라이드 변경
+              onGoToSlide(index);
+            } else {
+              // 일반 클릭시 location 상세 페이지로 이동
+              handleThumbnailClick(scene.id.toString(), event);
+            }
+          }}
           className={`relative aspect-video rounded-(--radius-xl) overflow-hidden cursor-pointer transition-all duration-300 ${
             index === currentIndex
               ? 'ring-2 ring-(--color-brand-secondary) scale-105'


### PR DESCRIPTION
## 🔗 연관된 이슈

Close #83 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

<img width="1668" height="1206" alt="image" src="https://github.com/user-attachments/assets/09f6b351-77a2-49ff-9763-6d17ff143072" />
4개까지 보도록 하였고 4개 이상인 경우 버튼이 생겨서 버튼을 누르면 모든 관련된 장소를 확인할 수 있습니다.
<img width="1670" height="1270" alt="image" src="https://github.com/user-attachments/assets/d423460d-3324-4519-9ae2-c68c9a8d40d4" />

장소가 4개 이하인 경우 버튼은 나타나지 않도록 설정해두었습니다.
컨텐츠 마다 포스터 크기가 일정하지 않아서 위에 이미지 들어가는 부분에서 맞지 않는 콘텐츠도 생겨서 이미지의 크기가
통일되어서 내려온다면 이 문제는 해결할 수 있을 것 같습니다.
장소상세 페이지의 버튼들은 다 동작합니다.
좋아요 버튼 이외에 버튼들은 다 동작하도록 수정해두었습니다.

## ✅ 테스트 체크리스트

- [x] 로컬 환경에서 정상 동작 확인 (build)
- [x] 관련 기능 수동 테스트 완료
- [x] PR을 보내는 브랜치를 다시 확인해주세요.


